### PR TITLE
feat: Add initFeatureFlags for execution mode detection

### DIFF
--- a/packages/@esta-core/feature-flags/.gitignore
+++ b/packages/@esta-core/feature-flags/.gitignore
@@ -1,0 +1,83 @@
+# src: .gitignore
+#
+## @(#) : gitignore for monorepo sub repository
+#
+# @version  1.0.0
+# @author   Furukawa, Atsushi <atsushifx@aglabo.com>
+# @since    2025-04-11
+# @license	MIT
+#
+# @description<<
+#
+# Git ignore rules for textlint plugin development.
+# Includes common Node.js patterns and workspace-specific overrides.
+#
+#<<
+
+## ─── General (logs, patches) ───────────────────────────────
+*.log*
+*.diff
+*.patch
+
+## ─── Editor (VSCode) ──────────────────────────────────────
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+!.vscode/cspell*
+
+.history/
+
+## ─── Node.js / JS project ignores ─────────────────────────
+# gibo: Node.gitignore
+logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Diagnostic reports
+report.*.json
+
+# Runtime files
+pids
+*.pid
+*.seed
+*.pid.lock
+
+## ─── TypeScript artifacts ────────────────────────────────
+*.tsbuildinfo
+
+## ─── Build outputs ───────────────────────────────────────
+dist/
+lib/
+module/
+
+
+## ─── Cache
+.cache/
+.rpt2_cache/
+.rts2_cache_*/
+.parcel-cache
+.vitest
+
+## --- temp
+temp/*
+tmp/*
+
+## ─── Lint and test caches ────────────────────────────────
+*cache
+.eslintcache
+.stylelintcache
+
+## ─── Others ───────────────────────────────────────────
+node_modules/
+*.tgz
+
+.env
+.env.*.local
+.tools
+

--- a/packages/@esta-core/feature-flags/.vscode/cspell.json
+++ b/packages/@esta-core/feature-flags/.vscode/cspell.json
@@ -1,0 +1,24 @@
+// @(#) : cspell settings for this workspace
+/**
+ *
+ * @version  1.0.0
+ * @author   Furukawa, Atsushi <https://github.com/atsushifx>
+ * @since    2025-02-27
+ * @license  MIT
+ *
+ * @description<<
+ *
+ * this file is cspell (Code Spell Checker) settings for this workspace.
+ *
+ *<<
+ */
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/packages/cspell-types/cspell.schema.json",
+  "version": "0.2",
+  "import": [
+    "${env:XDG_CONFIG_HOME}/vscode/cspell.config.json",
+    "../../../../.vscode/cspell.json"
+  ],
+  "language": "en",
+  "caseSensitive": true
+}

--- a/packages/@esta-core/feature-flags/configs/commitlint.config.ts
+++ b/packages/@esta-core/feature-flags/configs/commitlint.config.ts
@@ -1,0 +1,24 @@
+// src: commitlint.config.ts
+// @(#) : commitlint configuration for this workspace
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// import commitlint config type
+import type { UserConfig } from '@commitlint/types';
+
+// import base Config
+import { default as baseConfig } from '../../../../base/configs/commitlint.config.base';
+
+const config: UserConfig = {
+  ...baseConfig,
+  rules: {
+    ...baseConfig.rules,
+    // write rules if necessary
+    // 'header-max-length': [2, 'always', 72], etc
+  },
+};
+
+export default config;

--- a/packages/@esta-core/feature-flags/configs/eslint.config.js
+++ b/packages/@esta-core/feature-flags/configs/eslint.config.js
@@ -1,0 +1,33 @@
+// src: configs/eslint.config.js
+// @(#) : ESLint flat config for TypeScript workspace
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs
+
+// import form common base config
+import baseConfig from '../../../../base/configs/eslint.config.base.js';
+
+// settings
+export default [
+  ...baseConfig,
+
+  // source code settings
+  {
+    files: [
+      'src/**/*.ts',
+      'shared/**/*.ts',
+      'tests/**/*.ts',
+    ],
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
+  },
+];

--- a/packages/@esta-core/feature-flags/configs/eslint.config.typed.js
+++ b/packages/@esta-core/feature-flags/configs/eslint.config.typed.js
@@ -1,0 +1,41 @@
+// src: configs/eslint.config.typed.js
+// @(#) : eslint float config for type check
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// parser
+import tsparser from '@typescript-eslint/parser';
+
+// import form common base config
+import baseConfig from '../../../../base/configs/eslint.config.typed.base.js';
+
+export default [
+  ...baseConfig,
+  // --- source code
+  // source codes settings
+  {
+    files: [
+      'src/**/*.ts',
+      'shared/**/*.ts',
+      'tests/**/*.ts',
+    ],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: '.',
+        sourceType: 'module',
+      },
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
+  },
+];

--- a/packages/@esta-core/feature-flags/configs/secretlint.config.yaml
+++ b/packages/@esta-core/feature-flags/configs/secretlint.config.yaml
@@ -1,0 +1,10 @@
+# src: /shared/configs/secretlint.config.yaml
+# @(#) : secretlintrc
+#
+# Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+rules:
+  - id: "@secretlint/secretlint-rule-preset-recommend"

--- a/packages/@esta-core/feature-flags/configs/tsup.config.module.ts
+++ b/packages/@esta-core/feature-flags/configs/tsup.config.module.ts
@@ -1,0 +1,24 @@
+// src: configs/tsup.config.module.ts
+// @(#) : tsup config for esm module
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// system config
+import { defineConfig } from 'tsup';
+
+// user config
+import { baseConfig } from '../../../../base/configs/tsup.config.base';
+
+// configs
+export default defineConfig({
+  ...baseConfig,
+
+  // sub-packages definition
+  format: ['esm'],
+  outDir: 'module', // for ESM
+  // tsconfig
+  tsconfig: './tsconfig.json',
+});

--- a/packages/@esta-core/feature-flags/configs/tsup.config.ts
+++ b/packages/@esta-core/feature-flags/configs/tsup.config.ts
@@ -1,0 +1,23 @@
+// src: configs/tsup.config.ts
+// @(#) : tsup config for CommonJS module
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// system config
+import { defineConfig } from 'tsup';
+
+// user config
+import { baseConfig } from '../../../../base/configs/tsup.config.base';
+
+export default defineConfig({
+  ...baseConfig,
+
+  // sub packages definition
+  format: ['cjs'],
+  outDir: 'lib', // for CJS
+  // tsconfig
+  tsconfig: './tsconfig.json',
+});

--- a/packages/@esta-core/feature-flags/configs/vitest.config.ci.ts
+++ b/packages/@esta-core/feature-flags/configs/vitest.config.ci.ts
@@ -1,0 +1,43 @@
+// src: ./configs/vitest.config.ci.ts
+// @(#) : vitest config for integration test
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs for base directory
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// system config
+import { mergeConfig } from 'vitest/config';
+
+// user common config
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // CI Tests
+      'tests/**/*.test.ts',
+      'tests/**/*.spec.ts',
+      // Example E2E Tests
+      'example/e2e/**/*.test.ts',
+      'example/e2e/**/*.spec.ts',
+    ],
+    caches: {
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/ci/'),
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../src'),
+      '@shared': path.resolve(__dirname, '../shared'),
+    },
+  },
+});

--- a/packages/@esta-core/feature-flags/configs/vitest.config.unit.ts
+++ b/packages/@esta-core/feature-flags/configs/vitest.config.unit.ts
@@ -1,0 +1,40 @@
+// src: ./configs/vitest.config.unit.ts
+// @(#) : vitest config for unit test
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs for base directory
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// system config
+import { mergeConfig } from 'vitest/config';
+
+// user common config
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // Unit Test (develop test) exec only sub repositories
+      'src/**/*.test.ts',
+      'src/**/*.spec.ts',
+    ],
+    caches: {
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../src'),
+      '@shared': path.resolve(__dirname, '../shared/'),
+    },
+  },
+});

--- a/packages/@esta-core/feature-flags/package.json
+++ b/packages/@esta-core/feature-flags/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@esta-utils/utils",
+  "_comment": "@(#) @esta-core: ESTA Feature Flags",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Unified entry point for @esta-utils packages providing platform detection and command utilities.",
+  "author": "atsushifx <https://github.com/atsushifx>",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./lib/index.js",
+  "module": "./module/index.js",
+  "types": "./module/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./module/index.d.ts",
+      "import": "./module/index.js",
+      "require": "./lib/index.cjs"
+    }
+  },
+  "files": [
+    "lib",
+    "module"
+  ],
+  "scripts": {
+    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build:cjs": "tsup --config ./configs/tsup.config.ts",
+    "build:esm": "tsup --config ./configs/tsup.config.module.ts",
+    "clean": "rimraf lib module .cache",
+    "format:dprint": "dprint fmt",
+    "check:dprint": "dprint check",
+    "check:types": "tsc --noEmit --incremental",
+    "check:spells": "pnpm exec cspell --config .vscode/cspell.json --cache --cache-location ../../../.cache/cspell/cSpellCache",
+    "lint": "pnpm exec eslint --config ./configs/eslint.config.js --cache --cache-location ../../../.cache/eslint-cache/esLintCache ",
+    "lint:types": "pnpm exec eslint --config ./configs/eslint.config.typed.js --cache --cache-location ../../../.cache/eslint-cache/esLintCache",
+    "lint:all": "pnpm run lint && pnpm run lint:types",
+    "lint:fix": "pnpm run lint --fix",
+    "lint:secrets": "secretlint --secretlintrc ./configs/secretlint.config.yaml --secretlintignore .gitignore --maskSecrets **/*",
+    "test": "pnpm run test:develop && pnpm run test:ci",
+    "test:develop": "pnpm exec vitest run --config ./configs/vitest.config.unit.ts",
+    "test:ci": "pnpm exec vitest run --config ./configs/vitest.config.ci.ts",
+    "test:watch": "pnpm exec vitest --config ./configs/vitest.config.unit.ts --watch",
+    "sync:configs": "bash ../../../scripts/sync-configs.sh . "
+  },
+  "engines": {
+    "pnpm": ">=10",
+    "node": ">=20"
+  },
+  "dependencies": {
+  },
+  "devDependencies": {}
+}

--- a/packages/@esta-core/feature-flags/package.json
+++ b/packages/@esta-core/feature-flags/package.json
@@ -48,5 +48,7 @@
   },
   "dependencies": {
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@shared/constants": "workspace:*"
+  }
 }

--- a/packages/@esta-core/feature-flags/shared/constants/index.ts
+++ b/packages/@esta-core/feature-flags/shared/constants/index.ts
@@ -1,0 +1,9 @@
+// shared: ./constants/index.ts
+// 設定ローダー共通定数
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+export {}; // コンパイルエラー回避

--- a/packages/@esta-core/feature-flags/shared/types/featureFlags.ts
+++ b/packages/@esta-core/feature-flags/shared/types/featureFlags.ts
@@ -1,0 +1,17 @@
+// src: ./shared/types/featureFlags.ts
+// @(#) : ESTA Feature Flags
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// import { DISABLE, ENABLE } from '@shared/constants';
+
+export enum TEstaExecutionMode {
+  'GITHUB_ACTIONS' = 'GHA',
+  'CLI' = 'CLI',
+}
+
+export type TEstaFeatureFlags = {
+  executionMode: TEstaExecutionMode;
+};

--- a/packages/@esta-core/feature-flags/shared/types/featureFlags.ts
+++ b/packages/@esta-core/feature-flags/shared/types/featureFlags.ts
@@ -5,13 +5,79 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+/**
+ * @fileoverview ESTA機能フラグシステムの型定義
+ *
+ * このファイルはESTA(Easy Setup Tools Action)プロジェクトの機能フラグシステムで
+ * 使用される型定義を含んでいます。実行環境の判定や機能の切り替えに使用されます。
+ */
+
 // import { DISABLE, ENABLE } from '@shared/constants';
 
+/**
+ * ESTA実行モードの列挙型
+ *
+ * ESTAが実行される環境を表します。この値に基づいて機能フラグの
+ * 動作が決定されます。
+ *
+ * @enum {string}
+ * @readonly
+ *
+ * @example
+ * ```typescript
+ * // GitHub Actions環境での実行
+ * const mode = TEstaExecutionMode.GITHUB_ACTIONS; // 'GHA'
+ *
+ * // CLI環境での実行
+ * const mode = TEstaExecutionMode.CLI; // 'CLI'
+ * ```
+ */
 export enum TEstaExecutionMode {
+  /**
+   * GitHub Actions環境での実行
+   *
+   * GitHub ActionsのワークフロータスクやジョブのCI/CD環境での
+   * 実行を表します。
+   */
   'GITHUB_ACTIONS' = 'GHA',
+
+  /**
+   * CLI環境での実行
+   *
+   * ローカル開発環境やターミナルでの直接実行を表します。
+   */
   'CLI' = 'CLI',
 }
 
+/**
+ * ESTA機能フラグの設定型
+ *
+ * ESTA機能フラグシステムの設定を定義する型です。
+ * 実行モードに応じて機能の有効/無効を制御します。
+ *
+ * @interface
+ *
+ * @property {TEstaExecutionMode} executionMode - 現在の実行モード
+ *
+ * @example
+ * ```typescript
+ * // GitHub Actions環境用の設定
+ * const ghaFeatures: TEstaFeatureFlags = {
+ *   executionMode: TEstaExecutionMode.GITHUB_ACTIONS
+ * };
+ *
+ * // CLI環境用の設定
+ * const cliFeatures: TEstaFeatureFlags = {
+ *   executionMode: TEstaExecutionMode.CLI
+ * };
+ * ```
+ */
 export type TEstaFeatureFlags = {
+  /**
+   * 実行モード
+   *
+   * ESTAが実行される環境を示します。この値に基づいて
+   * 各機能の動作が決定されます。
+   */
   executionMode: TEstaExecutionMode;
 };

--- a/packages/@esta-core/feature-flags/shared/types/index.ts
+++ b/packages/@esta-core/feature-flags/shared/types/index.ts
@@ -6,4 +6,4 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-export {};
+export * from './featureFlags';

--- a/packages/@esta-core/feature-flags/shared/types/index.ts
+++ b/packages/@esta-core/feature-flags/shared/types/index.ts
@@ -1,0 +1,9 @@
+// src: /shared/types/index.ts
+// @(#) : types definition barrel file
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+export {};

--- a/packages/@esta-core/feature-flags/src/__tests__/initFeatureFlags.spec.ts
+++ b/packages/@esta-core/feature-flags/src/__tests__/initFeatureFlags.spec.ts
@@ -7,52 +7,88 @@
 // https://opensource.org/licenses/MIT
 
 // vitest
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // test target
 import { TEstaExecutionMode } from '../../shared/types/featureFlags';
-import { defaultFeatures, estaFeatures, initEstaFeatures } from '../initFeatureFlags';
+import { defaultFeatures, estaFeatures, getExecutionModeFromEnvironment, initEstaFeatures } from '../initFeatureFlags';
 
-describe('defaultFeatures', () => {
-  it('should be automatically set based on environment on import', () => {
-    // defaultFeaturesは環境に応じて設定される不変の初期値
-    expect([TEstaExecutionMode.GITHUB_ACTIONS, TEstaExecutionMode.CLI]).toContain(defaultFeatures.executionMode);
+describe('Feature Flags Module', () => {
+  describe('Environment Detection', () => {
+    describe('getExecutionModeFromEnvironment', () => {
+      beforeEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it('should return GITHUB_ACTIONS when GITHUB_ACTIONS=true', () => {
+        vi.stubEnv('GITHUB_ACTIONS', 'true');
+        const result = getExecutionModeFromEnvironment();
+        expect(result).toBe(TEstaExecutionMode.GITHUB_ACTIONS);
+      });
+
+      it('should return CLI when GITHUB_ACTIONS is not true', () => {
+        vi.stubEnv('GITHUB_ACTIONS', 'false');
+        const result = getExecutionModeFromEnvironment();
+        expect(result).toBe(TEstaExecutionMode.CLI);
+      });
+
+      it('should return CLI when GITHUB_ACTIONS is undefined', () => {
+        vi.stubEnv('GITHUB_ACTIONS', undefined);
+        const result = getExecutionModeFromEnvironment();
+        expect(result).toBe(TEstaExecutionMode.CLI);
+      });
+    });
+
+    describe('defaultFeatures', () => {
+      it('should be automatically set based on environment on import', () => {
+        // defaultFeaturesは環境に応じて設定される不変の初期値
+        expect([TEstaExecutionMode.GITHUB_ACTIONS, TEstaExecutionMode.CLI]).toContain(defaultFeatures.executionMode);
+      });
+    });
   });
-});
 
-describe('estaFeatures', () => {
-  it('should be independent from defaultFeatures', () => {
-    // defaultFeaturesとestaFeaturesは独立している
-    expect(estaFeatures).not.toBe(defaultFeatures);
-  });
-});
+  describe('Feature Flag State Management', () => {
+    describe('estaFeatures', () => {
+      it('should be independent from defaultFeatures', () => {
+        // defaultFeaturesとestaFeaturesは独立している
+        expect(estaFeatures).not.toBe(defaultFeatures);
+      });
+    });
 
-describe('initEstaFeatures', () => {
-  it('should override executionMode when parameter is specified', () => {
-    // パラメータでCLIを指定してinitEstaFeaturesを実行
-    const result = initEstaFeatures(TEstaExecutionMode.CLI);
+    describe('initEstaFeatures', () => {
+      describe('with explicit parameter', () => {
+        it('should override executionMode when parameter is specified', () => {
+          // パラメータでCLIを指定してinitEstaFeaturesを実行
+          const result = initEstaFeatures(TEstaExecutionMode.CLI);
 
-    // パラメータで指定した値になることを確認
-    expect(result.executionMode).toBe(TEstaExecutionMode.CLI);
-    expect(estaFeatures.executionMode).toBe(TEstaExecutionMode.CLI);
-  });
+          // パラメータで指定した値になることを確認
+          expect(result.executionMode).toBe(TEstaExecutionMode.CLI);
+          expect(estaFeatures.executionMode).toBe(TEstaExecutionMode.CLI);
+        });
+      });
 
-  it('should use defaultFeatures when no parameter is specified', () => {
-    // initEstaFeaturesを実行（パラメータなし）
-    const result = initEstaFeatures();
+      describe('without parameter', () => {
+        it('should use defaultFeatures when no parameter is specified', () => {
+          // initEstaFeaturesを実行（パラメータなし）
+          const result = initEstaFeatures();
 
-    // defaultFeaturesの値が使用されることを確認
-    expect(result.executionMode).toBe(defaultFeatures.executionMode);
-    expect(estaFeatures.executionMode).toBe(defaultFeatures.executionMode);
-  });
+          // defaultFeaturesの値が使用されることを確認
+          expect(result.executionMode).toBe(defaultFeatures.executionMode);
+          expect(estaFeatures.executionMode).toBe(defaultFeatures.executionMode);
+        });
+      });
 
-  it('should be able to switch between different modes', () => {
-    // GITHUB_ACTIONSモードに設定
-    initEstaFeatures(TEstaExecutionMode.GITHUB_ACTIONS);
-    expect(estaFeatures.executionMode).toBe(TEstaExecutionMode.GITHUB_ACTIONS);
+      describe('mode switching', () => {
+        it('should be able to switch between different modes', () => {
+          // GITHUB_ACTIONSモードに設定
+          initEstaFeatures(TEstaExecutionMode.GITHUB_ACTIONS);
+          expect(estaFeatures.executionMode).toBe(TEstaExecutionMode.GITHUB_ACTIONS);
 
-    // CLIモードに切り替え
-    initEstaFeatures(TEstaExecutionMode.CLI);
-    expect(estaFeatures.executionMode).toBe(TEstaExecutionMode.CLI);
+          // CLIモードに切り替え
+          initEstaFeatures(TEstaExecutionMode.CLI);
+          expect(estaFeatures.executionMode).toBe(TEstaExecutionMode.CLI);
+        });
+      });
+    });
   });
 });

--- a/packages/@esta-core/feature-flags/src/__tests__/initFeatureFlags.spec.ts
+++ b/packages/@esta-core/feature-flags/src/__tests__/initFeatureFlags.spec.ts
@@ -1,0 +1,58 @@
+// src: ./__tests__/initFeatureFlags.spec.ts
+// @(#) : initFeatureFlags test
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// vitest
+import { describe, expect, it } from 'vitest';
+
+// test target
+import { TEstaExecutionMode } from '../../shared/types/featureFlags';
+import { defaultFeatures, estaFeatures, initEstaFeatures } from '../initFeatureFlags';
+
+describe('defaultFeatures', () => {
+  it('should be automatically set based on environment on import', () => {
+    // defaultFeaturesは環境に応じて設定される不変の初期値
+    expect([TEstaExecutionMode.GITHUB_ACTIONS, TEstaExecutionMode.CLI]).toContain(defaultFeatures.executionMode);
+  });
+});
+
+describe('estaFeatures', () => {
+  it('should be independent from defaultFeatures', () => {
+    // defaultFeaturesとestaFeaturesは独立している
+    expect(estaFeatures).not.toBe(defaultFeatures);
+  });
+});
+
+describe('initEstaFeatures', () => {
+  it('should override executionMode when parameter is specified', () => {
+    // パラメータでCLIを指定してinitEstaFeaturesを実行
+    const result = initEstaFeatures(TEstaExecutionMode.CLI);
+
+    // パラメータで指定した値になることを確認
+    expect(result.executionMode).toBe(TEstaExecutionMode.CLI);
+    expect(estaFeatures.executionMode).toBe(TEstaExecutionMode.CLI);
+  });
+
+  it('should use defaultFeatures when no parameter is specified', () => {
+    // initEstaFeaturesを実行（パラメータなし）
+    const result = initEstaFeatures();
+
+    // defaultFeaturesの値が使用されることを確認
+    expect(result.executionMode).toBe(defaultFeatures.executionMode);
+    expect(estaFeatures.executionMode).toBe(defaultFeatures.executionMode);
+  });
+
+  it('should be able to switch between different modes', () => {
+    // GITHUB_ACTIONSモードに設定
+    initEstaFeatures(TEstaExecutionMode.GITHUB_ACTIONS);
+    expect(estaFeatures.executionMode).toBe(TEstaExecutionMode.GITHUB_ACTIONS);
+
+    // CLIモードに切り替え
+    initEstaFeatures(TEstaExecutionMode.CLI);
+    expect(estaFeatures.executionMode).toBe(TEstaExecutionMode.CLI);
+  });
+});

--- a/packages/@esta-core/feature-flags/src/__tests__/initFeatureFlags.spec.ts
+++ b/packages/@esta-core/feature-flags/src/__tests__/initFeatureFlags.spec.ts
@@ -13,8 +13,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TEstaExecutionMode } from '../../shared/types/featureFlags';
 import { defaultFeatures, estaFeatures, getExecutionModeFromEnvironment, initEstaFeatures } from '../initFeatureFlags';
 
+/**
+ * @fileoverview 機能フラグモジュールのテストスイート
+ *
+ * このファイルは@esta-core/feature-flagsパッケージの機能フラグシステムの
+ * 動作を検証するテストケースを含んでいます。
+ */
+
+/**
+ * 機能フラグモジュール全体のテストスイート
+ *
+ * 環境検出機能と機能フラグの状態管理機能をテストします。
+ */
 describe('Feature Flags Module', () => {
+  /**
+   * 環境検出機能のテストスイート
+   *
+   * 実行環境の自動判定とデフォルト値の設定に関するテストを行います。
+   */
   describe('Environment Detection', () => {
+    /**
+     * getExecutionModeFromEnvironment関数のテストスイート
+     *
+     * 環境変数GITHUB_ACTIONSの値に基づいて実行モードを正しく判定することを検証します。
+     */
     describe('getExecutionModeFromEnvironment', () => {
       beforeEach(() => {
         vi.restoreAllMocks();
@@ -39,6 +61,12 @@ describe('Feature Flags Module', () => {
       });
     });
 
+    /**
+     * defaultFeatures定数のテストスイート
+     *
+     * モジュールインポート時に環境に応じて自動設定される
+     * デフォルト機能フラグの動作を検証します。
+     */
     describe('defaultFeatures', () => {
       it('should be automatically set based on environment on import', () => {
         // defaultFeaturesは環境に応じて設定される不変の初期値
@@ -47,7 +75,17 @@ describe('Feature Flags Module', () => {
     });
   });
 
+  /**
+   * 機能フラグ状態管理のテストスイート
+   *
+   * 実行時の機能フラグ状態の管理と更新機能をテストします。
+   */
   describe('Feature Flag State Management', () => {
+    /**
+     * estaFeatures変数のテストスイート
+     *
+     * 実行時に変更可能な機能フラグ状態の基本的な動作を検証します。
+     */
     describe('estaFeatures', () => {
       it('should be independent from defaultFeatures', () => {
         // defaultFeaturesとestaFeaturesは独立している
@@ -55,7 +93,17 @@ describe('Feature Flags Module', () => {
       });
     });
 
+    /**
+     * initEstaFeatures関数のテストスイート
+     *
+     * 機能フラグの初期化処理とパラメータによる制御を検証します。
+     */
     describe('initEstaFeatures', () => {
+      /**
+       * 明示的なパラメータ指定時の動作テスト
+       *
+       * executionModeパラメータが指定された場合の動作を検証します。
+       */
       describe('with explicit parameter', () => {
         it('should override executionMode when parameter is specified', () => {
           // パラメータでCLIを指定してinitEstaFeaturesを実行
@@ -67,6 +115,11 @@ describe('Feature Flags Module', () => {
         });
       });
 
+      /**
+       * パラメータ未指定時の動作テスト
+       *
+       * executionModeパラメータが省略された場合の動作を検証します。
+       */
       describe('without parameter', () => {
         it('should use defaultFeatures when no parameter is specified', () => {
           // initEstaFeaturesを実行（パラメータなし）
@@ -78,6 +131,11 @@ describe('Feature Flags Module', () => {
         });
       });
 
+      /**
+       * 実行モード切り替え機能のテスト
+       *
+       * 異なる実行モード間での動的な切り替えが正しく動作することを検証します。
+       */
       describe('mode switching', () => {
         it('should be able to switch between different modes', () => {
           // GITHUB_ACTIONSモードに設定

--- a/packages/@esta-core/feature-flags/src/index.ts
+++ b/packages/@esta-core/feature-flags/src/index.ts
@@ -1,0 +1,9 @@
+// src: ./src/index.ts
+// @(#) : @esta-core: ESTA Feature Flags
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+export {};

--- a/packages/@esta-core/feature-flags/src/index.ts
+++ b/packages/@esta-core/feature-flags/src/index.ts
@@ -7,4 +7,11 @@
 // https://opensource.org/licenses/MIT
 
 // types
-export * from '../shared/types/feature-flags';
+export * from '../shared/types/featureFlags';
+
+// functions
+import { estaFeatures, initEstaFeatures } from './initFeatureFlags';
+export { estaFeatures, initEstaFeatures };
+
+// default
+export default estaFeatures;

--- a/packages/@esta-core/feature-flags/src/index.ts
+++ b/packages/@esta-core/feature-flags/src/index.ts
@@ -6,4 +6,5 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-export {};
+// types
+export * from '../shared/types/feature-flags';

--- a/packages/@esta-core/feature-flags/src/initFeatureFlags.ts
+++ b/packages/@esta-core/feature-flags/src/initFeatureFlags.ts
@@ -1,0 +1,38 @@
+// src: ./initFeatureFlags.ts
+// @(#) : initialize ESTA Feature Flags
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import type { TEstaFeatureFlags } from '../shared/types/featureFlags';
+import { TEstaExecutionMode } from '../shared/types/featureFlags';
+
+// 環境判定ロジック
+const getExecutionModeFromEnvironment = (): TEstaExecutionMode => {
+  return process.env.GITHUB_ACTIONS === 'true' ? TEstaExecutionMode.GITHUB_ACTIONS : TEstaExecutionMode.CLI;
+};
+
+// import時に自動的に環境判定を行ってdefaultFeaturesを設定（const、不変）
+export const defaultFeatures: TEstaFeatureFlags = {
+  executionMode: getExecutionModeFromEnvironment(),
+};
+
+// 現在のfeatureFlags状態を保持（let、可変）
+export let estaFeatures: TEstaFeatureFlags = {
+  ...defaultFeatures,
+};
+
+export const initEstaFeatures = (executionMode?: TEstaExecutionMode): TEstaFeatureFlags => {
+  // パラメータが指定されたらその値を使用、されなければdefaultFeaturesをコピー
+  const mode = executionMode ?? defaultFeatures.executionMode;
+
+  // estaFeaturesを更新
+  estaFeatures = {
+    ...defaultFeatures,
+    executionMode: mode,
+  };
+
+  return estaFeatures;
+};

--- a/packages/@esta-core/feature-flags/src/initFeatureFlags.ts
+++ b/packages/@esta-core/feature-flags/src/initFeatureFlags.ts
@@ -10,7 +10,7 @@ import type { TEstaFeatureFlags } from '../shared/types/featureFlags';
 import { TEstaExecutionMode } from '../shared/types/featureFlags';
 
 // 環境判定ロジック
-const getExecutionModeFromEnvironment = (): TEstaExecutionMode => {
+export const getExecutionModeFromEnvironment = (): TEstaExecutionMode => {
   return process.env.GITHUB_ACTIONS === 'true' ? TEstaExecutionMode.GITHUB_ACTIONS : TEstaExecutionMode.CLI;
 };
 

--- a/packages/@esta-core/feature-flags/src/initFeatureFlags.ts
+++ b/packages/@esta-core/feature-flags/src/initFeatureFlags.ts
@@ -9,21 +9,75 @@
 import type { TEstaFeatureFlags } from '../shared/types/featureFlags';
 import { TEstaExecutionMode } from '../shared/types/featureFlags';
 
-// 環境判定ロジック
+/**
+ * 環境変数を基に実行モードを判定する関数
+ *
+ * @returns {TEstaExecutionMode} 判定された実行モード
+ * - GITHUB_ACTIONS環境変数が'true'の場合: GITHUB_ACTIONS
+ * - それ以外の場合: CLI
+ *
+ * @example
+ * ```typescript
+ * // GitHub Actions環境で実行
+ * process.env.GITHUB_ACTIONS = 'true';
+ * const mode = getExecutionModeFromEnvironment(); // TEstaExecutionMode.GITHUB_ACTIONS
+ *
+ * // ローカル環境で実行
+ * process.env.GITHUB_ACTIONS = 'false';
+ * const mode = getExecutionModeFromEnvironment(); // TEstaExecutionMode.CLI
+ * ```
+ */
 export const getExecutionModeFromEnvironment = (): TEstaExecutionMode => {
   return process.env.GITHUB_ACTIONS === 'true' ? TEstaExecutionMode.GITHUB_ACTIONS : TEstaExecutionMode.CLI;
 };
 
-// import時に自動的に環境判定を行ってdefaultFeaturesを設定（const、不変）
+/**
+ * デフォルトの機能フラグ設定
+ *
+ * モジュールインポート時に環境を自動判定して設定される不変の初期値。
+ * この値は実行環境に応じて一度だけ設定され、以降は変更されません。
+ *
+ * @readonly
+ * @type {TEstaFeatureFlags}
+ */
 export const defaultFeatures: TEstaFeatureFlags = {
   executionMode: getExecutionModeFromEnvironment(),
 };
 
-// 現在のfeatureFlags状態を保持（let、可変）
+/**
+ * 現在の機能フラグ状態
+ *
+ * 実行時に変更可能な機能フラグの状態を保持します。
+ * initEstaFeatures関数によって更新されます。
+ *
+ * @type {TEstaFeatureFlags}
+ */
 export let estaFeatures: TEstaFeatureFlags = {
   ...defaultFeatures,
 };
 
+/**
+ * 機能フラグを初期化する関数
+ *
+ * @param {TEstaExecutionMode} [executionMode] - 設定する実行モード（省略時はdefaultFeaturesの値を使用）
+ * @returns {TEstaFeatureFlags} 初期化された機能フラグ設定
+ *
+ * @description
+ * 機能フラグの状態を初期化し、グローバルなestaFeatures変数を更新します。
+ * executionModeパラメータが指定されない場合は、defaultFeaturesの値が使用されます。
+ *
+ * @example
+ * ```typescript
+ * // 明示的にCLIモードで初期化
+ * const features = initEstaFeatures(TEstaExecutionMode.CLI);
+ *
+ * // デフォルト値で初期化（環境に応じて自動判定）
+ * const features = initEstaFeatures();
+ *
+ * // GitHub Actionsモードで初期化
+ * const features = initEstaFeatures(TEstaExecutionMode.GITHUB_ACTIONS);
+ * ```
+ */
 export const initEstaFeatures = (executionMode?: TEstaExecutionMode): TEstaFeatureFlags => {
   // パラメータが指定されたらその値を使用、されなければdefaultFeaturesをコピー
   const mode = executionMode ?? defaultFeatures.executionMode;

--- a/packages/@esta-core/feature-flags/tsconfig.json
+++ b/packages/@esta-core/feature-flags/tsconfig.json
@@ -1,0 +1,39 @@
+// src: ./tsconfig.json
+// @(#) : typescript compile settings
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+{
+  "extends": "../../../base/configs/tsconfig.base.json",
+  "include": [
+    "src/**/*.ts",
+    "shared/**/*.ts",
+    "tests/**/*.ts"
+  ],
+  "exclude": [
+    ".git",
+    "lib",
+    "module",
+    "node_modules",
+    ".cache",
+    "temp"
+  ],
+  "compilerOptions": {
+    // directories
+    "outDir": "lib",
+    "rootDir": "./",
+    // alias
+    "baseUrl": "./",
+    "paths": {
+      "@/*": [
+        "src/*",
+        "shared/*"
+      ]
+    },
+    // types
+    // cache
+    "tsBuildInfoFile": ".cache/tsbuild-cache/tsbuildinfo"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,11 @@ importers:
         specifier: ^4.2.5
         version: 4.2.5
 
-  packages/@esta-core/feature-flags: {}
+  packages/@esta-core/feature-flags:
+    devDependencies:
+      '@shared/constants':
+        specifier: workspace:*
+        version: link:../../../shared/packages/constants
 
   packages/@esta-utils/command-utils:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,8 @@ importers:
         specifier: ^4.2.5
         version: 4.2.5
 
+  packages/@esta-core/feature-flags: {}
+
   packages/@esta-utils/command-utils:
     dependencies:
       '@esta-utils/get-platform':


### PR DESCRIPTION
## ✨ Overview

Introduce `initFeatureFlags()` utility to determine runtime `executionMode` based on environment variables.  
Supports dynamic switching between `GITHUB_ACTIONS` and `CLI` contexts to facilitate context-aware feature flags.

> Example: Enables GitHub Actions-specific formatting when `GITHUB_ACTIONS=true`.

---

## 🔧 Changes

- [x] Added `initFeatureFlags()` function to `/src/initFeatureFlags.ts`
- [x] Added unit test file `/__tests__/initFeatureFlags.test.ts`
- [x] Refactored `TFeatureFlags` usage to support TDD-driven feature detection

---

## 📂 Related Issues

> Closes #87 

## ✅ Checklist

- [x] Lint checks pass (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [ ] Documentation is updated（自動生成またはREADME補足予定）
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

- Future extension: inject `.env`-driven feature flags via `dotenv` preload
- Consider adding `FeatureFlagProvider` for runtime override in testing
