### PR TITLE
docs: esta-config v2.0 + error-handler など仕様書群を整理・再構成

### DIFF
--- a/configs/eslint.config.all.typed.js
+++ b/configs/eslint.config.all.typed.js
@@ -55,6 +55,12 @@ export default [
         typescript: {
           project: projectPaths,
           tsconfigRootDir: rootDir,
+          noWarnOnMultipleProjects: true,
+          alwaysTryTypes: true,
+        },
+        node: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+          moduleDirectory: ['node_modules', 'src/'],
         },
       },
     },

--- a/configs/eslint.projects.js
+++ b/configs/eslint.projects.js
@@ -15,6 +15,7 @@ export default [
   './shared/packages/types/tsconfig.json',
   // esta-core
   'packages/@esta-core/feature-flags/tsconfig.json',
+  'packages/@esta-core/error-handler/tsconfig.json',
   // utils
   './packages/@esta-utils/utils/tsconfig.json',
   './packages/@esta-utils/command-utils/tsconfig.json',

--- a/packages/@esta-core/error-handler/shared/constants/exitCode.ts
+++ b/packages/@esta-core/error-handler/shared/constants/exitCode.ts
@@ -22,3 +22,20 @@ export const ExitCode = {
 } as const;
 
 export type TExitCode = typeof ExitCode[keyof typeof ExitCode];
+
+/**
+ * 終了コードに対応するエラーメッセージ定義
+ */
+export const ExitCodeErrorMessage = {
+  // 標準終了コード (0-1)
+  [ExitCode.SUCCESS]: 'Operation completed successfully',
+  [ExitCode.EXEC_FAILURE]: 'General execution failure',
+
+  // @esta-core独自の終了コード (11-99)
+  [ExitCode.CONFIG_NOT_FOUND]: 'Configuration file not found',
+  [ExitCode.COMMAND_EXECUTION_ERROR]: 'Command execution failed',
+  [ExitCode.INVALID_ARGS]: 'Invalid command line arguments',
+  [ExitCode.VALIDATION_FAILED]: 'Input validation failed',
+  [ExitCode.FILE_IO_ERROR]: 'File I/O operation failed',
+  [ExitCode.INTERNAL_LOGIC_ERROR]: 'Internal logic error occurred',
+} as const;

--- a/packages/@esta-core/error-handler/shared/constants/exitCode.ts
+++ b/packages/@esta-core/error-handler/shared/constants/exitCode.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/**
+ * POSIX準拠の終了コード定義
+ * 詳細は docs/detailed-design/exit-codes.md を参照
+ */
+export const ExitCode = {
+  // 標準終了コード (0-1)
+  SUCCESS: 0,
+  EXEC_FAILURE: 1,
+
+  // @esta-core独自の終了コード (11-99)
+  CONFIG_NOT_FOUND: 11,
+  COMMAND_EXECUTION_ERROR: 12,
+  INVALID_ARGS: 13,
+  VALIDATION_FAILED: 14,
+  FILE_IO_ERROR: 15,
+  INTERNAL_LOGIC_ERROR: 16,
+} as const;
+
+export type TExitCode = typeof ExitCode[keyof typeof ExitCode];

--- a/packages/@esta-core/error-handler/src/__tests__/errorExit.spec.ts
+++ b/packages/@esta-core/error-handler/src/__tests__/errorExit.spec.ts
@@ -1,0 +1,21 @@
+import { ExitCode } from '@shared/constants/exitCode';
+import { describe, expect, it } from 'vitest';
+import { ExitError } from '../error/ExitError';
+import { errorExit } from '../errorExit';
+
+describe('errorExit', () => {
+  it('should throw ExitError with fatal=false', () => {
+    expect(() => {
+      errorExit(ExitCode.INVALID_ARGS, 'invalid arguments');
+    }).toThrow(ExitError);
+
+    try {
+      errorExit(ExitCode.INVALID_ARGS, 'invalid arguments');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExitError);
+      expect((error as ExitError).isFatal()).toBe(false);
+      expect((error as ExitError).code).toBe(ExitCode.INVALID_ARGS);
+      expect((error as ExitError).message).toBe('invalid arguments');
+    }
+  });
+});

--- a/packages/@esta-core/error-handler/src/__tests__/fatalExit.spec.ts
+++ b/packages/@esta-core/error-handler/src/__tests__/fatalExit.spec.ts
@@ -1,0 +1,32 @@
+import { ExitCode } from '@shared/constants/exitCode';
+import { describe, expect, it } from 'vitest';
+import { ExitError } from '../error/ExitError';
+import { fatalExit } from '../fatalExit';
+
+describe('fatalExit', () => {
+  it('should throw ExitError with fatal=true and default code', () => {
+    expect(() => {
+      fatalExit('test fatal error');
+    }).toThrow(ExitError);
+
+    try {
+      fatalExit('test fatal error');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExitError);
+      expect((error as ExitError).isFatal()).toBe(true);
+      expect((error as ExitError).code).toBe(ExitCode.EXEC_FAILURE);
+      expect((error as ExitError).message).toBe('test fatal error');
+    }
+  });
+
+  it('should throw ExitError with fatal=true and custom code', () => {
+    try {
+      fatalExit('config not found', ExitCode.CONFIG_NOT_FOUND);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExitError);
+      expect((error as ExitError).isFatal()).toBe(true);
+      expect((error as ExitError).code).toBe(ExitCode.CONFIG_NOT_FOUND);
+      expect((error as ExitError).message).toBe('config not found');
+    }
+  });
+});

--- a/packages/@esta-core/error-handler/src/error/ExitError.ts
+++ b/packages/@esta-core/error-handler/src/error/ExitError.ts
@@ -1,0 +1,22 @@
+import type { TExitCode } from '@shared/constants/exitCode';
+
+export class ExitError extends Error {
+  readonly code: TExitCode;
+  readonly fatal: boolean;
+
+  constructor(code: TExitCode, message: string, fatal = false) {
+    super(message);
+    this.name = 'ExitError';
+    this.code = code;
+    this.fatal = fatal;
+    Object.setPrototypeOf(this, new.target.prototype);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ExitError);
+    }
+  }
+
+  isFatal(): boolean {
+    return this.fatal;
+  }
+}

--- a/packages/@esta-core/error-handler/src/error/__tests__/ExitError.spec.ts
+++ b/packages/@esta-core/error-handler/src/error/__tests__/ExitError.spec.ts
@@ -1,0 +1,25 @@
+import { ExitCode } from '@shared/constants/exitCode';
+import { describe, expect, it } from 'vitest';
+import { ExitError } from '../ExitError';
+
+describe('ExitError', () => {
+  it('should extend Error class', () => {
+    const error = new ExitError(ExitCode.EXEC_FAILURE, 'test message');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('should have code property with correct value', () => {
+    const error = new ExitError(ExitCode.CONFIG_NOT_FOUND, 'test message');
+    expect(error.code).toBe(ExitCode.CONFIG_NOT_FOUND);
+  });
+
+  it('should have isFatal method that returns false by default', () => {
+    const error = new ExitError(ExitCode.EXEC_FAILURE, 'test message');
+    expect(error.isFatal()).toBe(false);
+  });
+
+  it('should have isFatal method that returns true when fatal=true', () => {
+    const error = new ExitError(ExitCode.EXEC_FAILURE, 'test message', true);
+    expect(error.isFatal()).toBe(true);
+  });
+});

--- a/packages/@esta-core/error-handler/src/errorExit.ts
+++ b/packages/@esta-core/error-handler/src/errorExit.ts
@@ -1,0 +1,9 @@
+import type { TExitCode } from '@shared/constants/exitCode';
+import { ExitError } from './error/ExitError';
+
+export const errorExit = (
+  code: TExitCode,
+  message: string,
+): never => {
+  throw new ExitError(code, message);
+};

--- a/packages/@esta-core/error-handler/src/errorExit.ts
+++ b/packages/@esta-core/error-handler/src/errorExit.ts
@@ -1,9 +1,13 @@
 import type { TExitCode } from '@shared/constants/exitCode';
+import { ExitCodeErrorMessage } from '@shared/constants/exitCode';
 import { ExitError } from './error/ExitError';
 
 export const errorExit = (
   code: TExitCode,
   message: string,
 ): never => {
+  const defaultMessage = ExitCodeErrorMessage[code] || `Unknown error (exit code: ${code})`;
+  console.error(`Error: ${defaultMessage}`);
+  console.error(`Message: ${message}`);
   throw new ExitError(code, message);
 };

--- a/packages/@esta-core/error-handler/src/fatalExit.ts
+++ b/packages/@esta-core/error-handler/src/fatalExit.ts
@@ -1,9 +1,13 @@
 import { ExitCode, type TExitCode } from '@shared/constants/exitCode';
+import { ExitCodeErrorMessage } from '@shared/constants/exitCode';
 import { ExitError } from './error/ExitError';
 
 export const fatalExit = (
   message: string,
   code: TExitCode = ExitCode.EXEC_FAILURE,
 ): never => {
+  const defaultMessage = ExitCodeErrorMessage[code] || `Unknown error (exit code: ${code})`;
+  console.error(`Fatal Error: ${defaultMessage}`);
+  console.error(`Message: ${message}`);
   throw new ExitError(code, message, true);
 };

--- a/packages/@esta-core/error-handler/src/fatalExit.ts
+++ b/packages/@esta-core/error-handler/src/fatalExit.ts
@@ -1,0 +1,9 @@
+import { ExitCode, type TExitCode } from '@shared/constants/exitCode';
+import { ExitError } from './error/ExitError';
+
+export const fatalExit = (
+  message: string,
+  code: TExitCode = ExitCode.EXEC_FAILURE,
+): never => {
+  throw new ExitError(code, message, true);
+};

--- a/packages/@esta-core/error-handler/src/index.ts
+++ b/packages/@esta-core/error-handler/src/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// 基本機能のエクスポート
+export { ExitCode } from '@shared/constants/exitCode';
+export type { TExitCode } from '@shared/constants/exitCode';
+export { ExitError } from './error/ExitError';
+export { errorExit } from './errorExit';
+export { fatalExit } from './fatalExit';

--- a/packages/@esta-core/error-handler/tsconfig.json
+++ b/packages/@esta-core/error-handler/tsconfig.json
@@ -30,6 +30,9 @@
       "@/*": [
         "src/*",
         "shared/*"
+      ],
+      "@shared/*": [
+        "shared/*"
       ]
     },
     // types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,12 @@ importers:
         specifier: ^4.2.5
         version: 4.2.5
 
+  packages/@esta-core/error-handler:
+    dependencies:
+      '@agla-utils/ag-logger':
+        specifier: workspace:*
+        version: link:../../@agla-utils/ag-logger
+
   packages/@esta-core/feature-flags:
     devDependencies:
       '@shared/constants':


### PR DESCRIPTION
## ✨ Overview

本 PR では `docs/specs/` 配下にある複数のモジュール仕様書を統合的に整理し、以下の改善・簡略化を行いました。

- `@esta-core/config` の設計を ver 2.0.0 にアップデート（構成最小化＋tools外出し）
- `error-handler`, `feature-flags`, `esta-executor` など他仕様書と整合を取ったドキュメント配置
- `docs/` 構成の標準化と Vale, Lint 対応前提のリファクタ

---

## 🔧 Changes

- [x] `docs/specs/esta-config-spec.md` を ver 2.0.0 として全面改訂
- [x] 実行制御フラグ（dryRun 等）は `.estarc` ではなく flags として分離記述 (補遺に記載)
- [x] `docs/specs/error-handler-spec.md` を初期構成とともに整理・位置調整
- [x] `docs/specs/feature-flags-spec.md` との整合を確認し、リンク構造を整理
- [x] ドキュメント全体の言語/見出し/構成の一貫性を調整

---

## 📂 Related Issues

- Closes #94
- Related: `@esta-core/tools-config` の仕様分離提案  
- Related: エラーハンドラー設計標準化 #88（継続中）

---

## ✅ Checklist

- [x] すべての .md ファイルが lint 済みである
- [x] 仕様書の構成がバージョンラベル付きで追跡可能
- [x] CLI/CI での利用に関する補足が各仕様書に含まれる
- [x] `.estarc` と `.tools.config.json` の分離構成が明記されている

---

## 💬 Additional Notes

今後予定：

- `tools-config` モジュールの初期化・スキーマ策定
- `execution-context` の共通型設計と CLI 実行制御モジュール化
