### PR TITLE
feat(ag-logger): E2eMockLoggerプラグインを追加し、E2Eテストを強化

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typescript",
     "monorepo"
   ],
-  "packageManager": "pnpm@10.12.4",
+  "packageManager": "pnpm@10.13.1",
   "scripts": {
     "build": "pnpm -r run build",
     "build:esm": "pnpm -r run build:esm",
@@ -39,7 +39,6 @@
     "test:gha": "pnpm exec vitest run --config ./configs/vitest.config.gha.ts",
     "sync:configs": "bash scripts/sync-configs.sh"
   },
-  "dependencies": {},
   "devDependencies": {
     "@commitlint/config-conventional": "^19.8.1",
     "@commitlint/types": "^19.8.1",

--- a/packages/@agla-utils/ag-logger/src/index.ts
+++ b/packages/@agla-utils/ag-logger/src/index.ts
@@ -23,6 +23,7 @@ export { AgLogger, getLogger } from './AgLogger.class';
 
 // plugins: logger
 export { ConsoleLogger } from './plugins/logger/ConsoleLogger';
+export { E2eMockLogger } from './plugins/logger/E2eMockLogger';
 export { NullLogger } from './plugins/logger/NullLogger';
 
 // plugins: format

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
@@ -1,0 +1,77 @@
+// src/plugins/logger/E2eMockLogger.ts
+// @(#) : E2E Mock Logger Implementation
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// types
+import type { AgLogLevel } from '@shared/types';
+import { AgLogLevelCode } from '@shared/types';
+
+/**
+ * Mock logger for E2E testing that captures log messages in arrays.
+ * Uses 2D array structure for efficient log level management.
+ */
+export class E2eMockLogger {
+  private messages: string[][] = [
+    [], // OFF (0) - not used for actual logging
+    [], // FATAL (1)
+    [], // ERROR (2)
+    [], // WARN (3)
+    [], // INFO (4)
+    [], // DEBUG (5)
+    [], // TRACE (6)
+  ];
+
+  fatal(message: string): void {
+    this.messages[AgLogLevelCode.FATAL].push(message);
+  }
+
+  error(message: string): void {
+    this.messages[AgLogLevelCode.ERROR].push(message);
+  }
+
+  warn(message: string): void {
+    this.messages[AgLogLevelCode.WARN].push(message);
+  }
+
+  info(message: string): void {
+    this.messages[AgLogLevelCode.INFO].push(message);
+  }
+
+  debug(message: string): void {
+    this.messages[AgLogLevelCode.DEBUG].push(message);
+  }
+
+  trace(message: string): void {
+    this.messages[AgLogLevelCode.TRACE].push(message);
+  }
+
+  getMessages(logLevel: AgLogLevel): string[] {
+    return [...this.messages[logLevel]];
+  }
+
+  getLastMessage(logLevel: AgLogLevel): string | null {
+    const levelMessages = this.messages[logLevel];
+    return levelMessages[levelMessages.length - 1] || null;
+  }
+
+  clearMessages(logLevel: AgLogLevel): void {
+    this.messages[logLevel] = [];
+  }
+
+  // Legacy methods for backward compatibility
+  getErrorMessages(): string[] {
+    return this.getMessages(AgLogLevelCode.ERROR);
+  }
+
+  getLastErrorMessage(): string | null {
+    return this.getLastMessage(AgLogLevelCode.ERROR);
+  }
+
+  clearErrorMessages(): void {
+    this.clearMessages(AgLogLevelCode.ERROR);
+  }
+}

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/__tests__/E2eMockLogger.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/__tests__/E2eMockLogger.spec.ts
@@ -1,0 +1,96 @@
+// src/plugins/logger/__tests__/E2eMockLogger.spec.ts
+// @(#) : E2eMockLogger Unit Test
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// vitest
+import { beforeEach, describe, expect, it } from 'vitest';
+
+// types
+import { AgLogLevelCode } from '@shared/types';
+
+// test target
+import { E2eMockLogger } from '../E2eMockLogger';
+
+describe('E2eMockLogger', () => {
+  let mockLogger: E2eMockLogger;
+
+  beforeEach(() => {
+    mockLogger = new E2eMockLogger();
+  });
+
+  describe('基本機能: errorメッセージを配列に保存できる', () => {
+    it('should store error messages in array', () => {
+      mockLogger.error('First error');
+      mockLogger.error('Second error');
+
+      const errorMessages = mockLogger.getErrorMessages();
+      expect(errorMessages).toEqual(['First error', 'Second error']);
+    });
+  });
+
+  describe('基本機能: 最後のerrorメッセージを取得できる', () => {
+    it('should return last error message', () => {
+      mockLogger.error('First error');
+      mockLogger.error('Second error');
+
+      const lastError = mockLogger.getLastErrorMessage();
+      expect(lastError).toBe('Second error');
+    });
+
+    it('should return null when no error messages', () => {
+      const lastError = mockLogger.getLastErrorMessage();
+      expect(lastError).toBeNull();
+    });
+  });
+
+  describe('基本機能: errorメッセージをクリアできる', () => {
+    it('should clear error messages', () => {
+      mockLogger.error('First error');
+      mockLogger.error('Second error');
+
+      mockLogger.clearErrorMessages();
+
+      const errorMessages = mockLogger.getErrorMessages();
+      expect(errorMessages).toEqual([]);
+      expect(mockLogger.getLastErrorMessage()).toBeNull();
+    });
+  });
+
+  describe('統一API設計: getLastMessage(logLevel)で統一', () => {
+    it('should get last message for each level using unified method', () => {
+      mockLogger.fatal('Fatal 1');
+      mockLogger.fatal('Fatal 2');
+      mockLogger.error('Error 1');
+      mockLogger.error('Error 2');
+
+      expect(mockLogger.getLastMessage(AgLogLevelCode.FATAL)).toBe('Fatal 2');
+      expect(mockLogger.getLastMessage(AgLogLevelCode.ERROR)).toBe('Error 2');
+      expect(mockLogger.getLastMessage(AgLogLevelCode.WARN)).toBeNull();
+    });
+
+    it('should get messages for each level using unified method', () => {
+      mockLogger.fatal('Fatal message');
+      mockLogger.error('Error message');
+      mockLogger.warn('Warn message');
+
+      expect(mockLogger.getMessages(AgLogLevelCode.FATAL)).toEqual(['Fatal message']);
+      expect(mockLogger.getMessages(AgLogLevelCode.ERROR)).toEqual(['Error message']);
+      expect(mockLogger.getMessages(AgLogLevelCode.WARN)).toEqual(['Warn message']);
+      expect(mockLogger.getMessages(AgLogLevelCode.INFO)).toEqual([]);
+    });
+
+    it('should clear messages for specific level using unified method', () => {
+      mockLogger.fatal('Fatal message');
+      mockLogger.error('Error message');
+
+      mockLogger.clearMessages(AgLogLevelCode.FATAL);
+
+      expect(mockLogger.getMessages(AgLogLevelCode.FATAL)).toEqual([]);
+      expect(mockLogger.getMessages(AgLogLevelCode.ERROR)).toEqual(['Error message']);
+    });
+  });
+});

--- a/packages/@esta-core/error-handler/src/error/ExitError.ts
+++ b/packages/@esta-core/error-handler/src/error/ExitError.ts
@@ -10,7 +10,7 @@ export class ExitError extends Error {
     this.code = code;
     this.fatal = fatal;
     Object.setPrototypeOf(this, new.target.prototype);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ExitError);
     }


### PR DESCRIPTION
## ✨ Overview

This Pull Request introduces a new `E2eMockLogger` plugin designed to support end-to-end (E2E) testing by capturing and verifying log output by log level.

It enhances the E2E testing infrastructure of ESTA, ensuring accurate and granular logging behavior validation.

---

## 🔧 Changes

- [x] Exported `E2eMockLogger` from `index.ts` for plugin use in tests
- [x] Created `E2eMockLogger.ts`, a custom logger that captures logs by level for inspection
- [x] Added comprehensive unit tests in `__tests__/E2eMockLogger.spec.ts` to validate logger behavior
- [x] Removed unnecessary ESLint disable comment from `ExitError.ts` constructor

---

## 📂 Related Issues

N/A

---

## ✅ Checklist

- [ ] Lint checks pass (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Descriptions and examples are clear

---

## 💬 Additional Notes

This plugin enables more robust validation of log output during E2E scenarios by programmatically capturing logs by type (info, warn, error, etc.).  
No impact to production code or runtime logic—this is strictly a dev/test utility.
