### PR TITLE
Refactor/configs-unify

### DIFF
--- a/packages/@agla-e2e/fileio-framework/configs/eslint.config.js
+++ b/packages/@agla-e2e/fileio-framework/configs/eslint.config.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.js
 // @(#) : ESLint flat config for TypeScript workspace
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@agla-e2e/fileio-framework/configs/eslint.config.typed.js
+++ b/packages/@agla-e2e/fileio-framework/configs/eslint.config.typed.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.typed.js
 // @(#) : eslint float config for type check
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@agla-e2e/fileio-framework/configs/tsup.config.module.ts
+++ b/packages/@agla-e2e/fileio-framework/configs/tsup.config.module.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.module.ts
 // @(#) : tsup config for esm module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@agla-e2e/fileio-framework/configs/tsup.config.ts
+++ b/packages/@agla-e2e/fileio-framework/configs/tsup.config.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.ts
 // @(#) : tsup config for CommonJS module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@agla-e2e/fileio-framework/configs/vitest.config.ci.ts
+++ b/packages/@agla-e2e/fileio-framework/configs/vitest.config.ci.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.ci.ts
 // @(#) : vitest config for integration test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@agla-e2e/fileio-framework/configs/vitest.config.unit.ts
+++ b/packages/@agla-e2e/fileio-framework/configs/vitest.config.unit.ts
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@agla-e2e/fileio-framework/configs/vitest.config.unit.ts
+++ b/packages/@agla-e2e/fileio-framework/configs/vitest.config.unit.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.unit.ts
 // @(#) : vitest config for unit test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@agla-e2e/fileio-framework/tsconfig.json
+++ b/packages/@agla-e2e/fileio-framework/tsconfig.json
@@ -30,10 +30,7 @@
     // "paths": {},
     "paths": {
       "@/*": [
-        "src/*"
-      ],
-      "@shared/*": [
-        "shared/*"
+        "./src/*"
       ]
     },
     // types

--- a/packages/@agla-utils/ag-logger/configs/vitest.config.ci.ts
+++ b/packages/@agla-utils/ag-logger/configs/vitest.config.ci.ts
@@ -1,5 +1,5 @@
-// src: ./configs/vitest.config.unit.ts
-// @(#) : vitest config for unit test
+// src: ./configs/vitest.config.ci.ts
+// @(#) : vitest config for integration test
 //
 // Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'tests/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/ci'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/ci/'),
     },
   },
   resolve: {

--- a/packages/@agla-utils/ag-logger/configs/vitest.config.unit.ts
+++ b/packages/@agla-utils/ag-logger/configs/vitest.config.unit.ts
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@agla-utils/ag-logger/configs/vitest.config.unit.ts
+++ b/packages/@agla-utils/ag-logger/configs/vitest.config.unit.ts
@@ -34,7 +34,6 @@ export default mergeConfig(baseConfig, {
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '../src'),
-      '@shared': path.resolve(__dirname, '../shared'),
     },
   },
 });

--- a/packages/@agla-utils/ag-logger/shared/constants/AgLogger.constants.ts
+++ b/packages/@agla-utils/ag-logger/shared/constants/AgLogger.constants.ts
@@ -7,9 +7,9 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { AgLogLevel } from '@shared/types/AgLogger.types';
+import type { AgLogLevel } from '../types/AgLogger.types';
 // code
-import { AgLogLevelCode } from '@shared/types/AgLogger.types';
+import { AgLogLevelCode } from '../types/AgLogger.types';
 
 /**
  * Mapping of `AgLogLevel` numeric codes to their string label names.

--- a/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
@@ -7,10 +7,10 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { AgLogLevel } from '@shared/types';
-import { AgLogLevelCode } from '@shared/types';
+import type { AgLogLevel } from '../shared/types';
+import { AgLogLevelCode } from '../shared/types';
 // interfaces
-import type { AgFormatFunction, AgLoggerFunction, AgLoggerMap } from '@shared/types/AgLogger.interface';
+import type { AgFormatFunction, AgLoggerFunction, AgLoggerMap } from '../shared/types/AgLogger.interface';
 
 // core
 import { AgLoggerManager } from './AgLoggerManager.class';

--- a/packages/@agla-utils/ag-logger/src/AgLoggerManager.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLoggerManager.class.ts
@@ -7,10 +7,10 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { AgFormatFunction, AgLoggerFunction, AgLoggerMap } from '@shared/types/AgLogger.interface';
-import type { AgLogLevel } from '@shared/types/AgLogger.types';
+import type { AgFormatFunction, AgLoggerFunction, AgLoggerMap } from '../shared/types/AgLogger.interface';
+import type { AgLogLevel } from '../shared/types/AgLogger.types';
 // code
-import { AgLogLevelCode } from '@shared/types/AgLogger.types';
+import { AgLogLevelCode } from '../shared/types/AgLogger.types';
 
 // plugins
 import { NullFormat } from '@/plugins/format/NullFormat';

--- a/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.spec.ts
@@ -10,7 +10,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // constants
-import { AgLogLevelCode } from '@shared/types';
+import { AgLogLevelCode } from '../../shared/types';
 
 // test target
 import { AgLogger } from '../AgLogger.class';

--- a/packages/@agla-utils/ag-logger/src/__tests__/AgLoggerManager.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/AgLoggerManager.spec.ts
@@ -10,9 +10,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // constants
-import { AgLogLevelCode } from '@shared/types';
+import { AgLogLevelCode } from '../../shared/types';
 // types
-import type { AgLogLevel } from '@shared/types';
+import type { AgLogLevel } from '../../shared/types';
 
 // test target
 import { AgLoggerManager } from '../AgLoggerManager.class';

--- a/packages/@agla-utils/ag-logger/src/index.ts
+++ b/packages/@agla-utils/ag-logger/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 // types
-export { AgLogLevel, AgLogLevelCode } from '@shared/types';
+export { AgLogLevel, AgLogLevelCode } from '../shared/types';
 
 // logger main
 export { AgLogger, getLogger } from './AgLogger.class';

--- a/packages/@agla-utils/ag-logger/src/plugins/format/JsonFormat.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/format/JsonFormat.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { AgLogMessage } from '@shared/types';
+import type { AgLogMessage } from '../../../shared/types';
 
 // utilities
 import { AgLoggerGetLabel } from '../../utils/AgLoggerHelpers';

--- a/packages/@agla-utils/ag-logger/src/plugins/format/NullFormat.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/format/NullFormat.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { AgFormatFunction, AgLogMessage } from '@shared/types';
+import type { AgFormatFunction, AgLogMessage } from '../../../shared/types';
 
 /**
  * Null formatter that always returns an empty string,

--- a/packages/@agla-utils/ag-logger/src/plugins/format/PlainFormat.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/format/PlainFormat.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { AgFormatFunction, AgLogMessage } from '@shared/types';
+import type { AgFormatFunction, AgLogMessage } from '../../../shared/types';
 
 // utils
 import { AgLoggerGetLabel } from '../../utils/AgLoggerHelpers';

--- a/packages/@agla-utils/ag-logger/src/plugins/format/__tests__/JsonFormat.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/format/__tests__/JsonFormat.spec.ts
@@ -10,9 +10,9 @@
 import { describe, expect, it } from 'vitest';
 
 // constants
-import { AgLogLevelCode } from '@shared/types';
+import { AgLogLevelCode } from '../../../../shared/types';
 // type
-import type { AgLogMessage } from '@shared/types';
+import type { AgLogMessage } from '../../../../shared/types';
 
 // test unit
 import { JsonFormat } from '../JsonFormat';

--- a/packages/@agla-utils/ag-logger/src/plugins/format/__tests__/NullFormat.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/format/__tests__/NullFormat.spec.ts
@@ -10,9 +10,9 @@
 import { describe, expect, it } from 'vitest';
 
 // constants
-import { AgLogLevelCode } from '@shared/types';
+import { AgLogLevelCode } from '../../../../shared/types';
 // types
-import type { AgLogMessage } from '@shared/types';
+import type { AgLogMessage } from '../../../../shared/types';
 
 // subject under test
 import { NullFormat } from '../NullFormat';

--- a/packages/@agla-utils/ag-logger/src/plugins/format/__tests__/PlainFormat.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/format/__tests__/PlainFormat.spec.ts
@@ -10,9 +10,9 @@
 import { describe, expect, it } from 'vitest';
 
 // constants
-import { AgLogLevelCode } from '@shared/types';
+import { AgLogLevelCode } from '../../../../shared/types';
 // types
-import type { AgLogMessage } from '@shared/types';
+import type { AgLogMessage } from '../../../../shared/types';
 
 // subject under test
 import { PlainFormat } from '../PlainFormat';

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/ConsoleLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/ConsoleLogger.ts
@@ -8,9 +8,9 @@
 
 // --- modules
 // constants
-import { AgLogLevelCode } from '@shared/types';
+import { AgLogLevelCode } from '../../../shared/types';
 // types
-import type { AgLoggerFunction, AgLoggerMap } from '@shared/types/AgLogger.interface';
+import type { AgLoggerFunction, AgLoggerMap } from '../../../shared/types/AgLogger.interface';
 
 // logger if log level is OFF
 import { NullLogger } from './NullLogger';

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
@@ -7,8 +7,8 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { AgLogLevel } from '@shared/types';
-import { AgLogLevelCode } from '@shared/types';
+import type { AgLogLevel } from '../../../shared/types';
+import { AgLogLevelCode } from '../../../shared/types';
 
 /**
  * Mock logger for E2E testing that captures log messages in arrays.

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/NullLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/NullLogger.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { AgLoggerFunction } from '@shared/types/AgLogger.interface';
+import type { AgLoggerFunction } from '../../../shared/types/AgLogger.interface';
 
 /**
  * Null logger function that performs no operations.

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/__tests__/ConsoleLogger.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/__tests__/ConsoleLogger.spec.ts
@@ -10,7 +10,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // constants
-import { AgLogLevelCode } from '@shared/types';
+import { AgLogLevelCode } from '../../../../shared/types';
 
 // test subject
 import { ConsoleLogger, ConsoleLoggerMap } from '../ConsoleLogger';

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/__tests__/E2eMockLogger.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/__tests__/E2eMockLogger.spec.ts
@@ -10,7 +10,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 // types
-import { AgLogLevelCode } from '@shared/types';
+import { AgLogLevelCode } from '../../../../shared/types';
 
 // test target
 import { E2eMockLogger } from '../E2eMockLogger';

--- a/packages/@agla-utils/ag-logger/src/utils/AgLoggerGetMessage.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/AgLoggerGetMessage.ts
@@ -6,7 +6,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import type { AgLogLevel, AgLogMessage } from '@shared/types/AgLogger.types';
+import type { AgLogLevel, AgLogMessage } from '../../shared/types/AgLogger.types';
 
 /**
  * Parses log arguments into a structured log message object.

--- a/packages/@agla-utils/ag-logger/src/utils/AgLoggerHelpers.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/AgLoggerHelpers.ts
@@ -7,9 +7,9 @@
 // https://opensource.org/licenses/MIT
 
 // constants
-import { AgLogLevelLabels } from '@shared/constants/AgLogger.constants';
+import { AgLogLevelLabels } from '../../shared/constants/AgLogger.constants';
 // types
-import type { AgLogLevel } from '@shared/types';
+import type { AgLogLevel } from '../../shared/types';
 
 /**
  * Returns the uppercase string label corresponding to a given log level code.

--- a/packages/@agla-utils/ag-logger/src/utils/__tests__/AgLoggerGetLabel.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/__tests__/AgLoggerGetLabel.spec.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from 'vitest';
 
 // constants
-import { AgLogLevelCode } from '@shared/types';
+import { AgLogLevelCode } from '../../../shared/types';
 
 // test subject
 import { AgLoggerGetLabel } from '../AgLoggerHelpers';

--- a/packages/@agla-utils/ag-logger/src/utils/__tests__/AgLoggerGetMessage.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/__tests__/AgLoggerGetMessage.spec.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from 'vitest';
 
 // constants
-import { AgLogLevelCode } from '@shared/types/AgLogger.types';
+import { AgLogLevelCode } from '../../../shared/types/AgLogger.types';
 
 // test target
 import { AgLoggerGetMessage } from '../AgLoggerGetMessage';

--- a/packages/@agla-utils/ag-logger/tsconfig.json
+++ b/packages/@agla-utils/ag-logger/tsconfig.json
@@ -17,7 +17,8 @@
     "lib",
     "module",
     "node_modules",
-    ".cache"
+    ".cache",
+    "temp"
   ],
   "compilerOptions": {
     // directories
@@ -28,10 +29,7 @@
     // "paths": {},
     "paths": {
       "@/*": [
-        "src/*"
-      ],
-      "@shared/*": [
-        "shared/*"
+        "./src/*"
       ]
     },
     // types

--- a/packages/@esta-actions/tools-installer/configs/vitest.config.unit.ts
+++ b/packages/@esta-actions/tools-installer/configs/vitest.config.unit.ts
@@ -30,7 +30,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
     },
   },
   resolve: {

--- a/packages/@esta-actions/tools-installer/configs/vitest.config.unit.ts
+++ b/packages/@esta-actions/tools-installer/configs/vitest.config.unit.ts
@@ -30,7 +30,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@esta-actions/tools-installer/tsconfig.json
+++ b/packages/@esta-actions/tools-installer/tsconfig.json
@@ -17,7 +17,8 @@
     "lib",
     "module",
     "node_modules",
-    ".cache"
+    ".cache",
+    "temp"
   ],
   "compilerOptions": {
     // directories
@@ -27,7 +28,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": [
-        "src/*"
+        "./src/*"
       ]
     },
     // types

--- a/packages/@esta-core/error-handler/configs/eslint.config.js
+++ b/packages/@esta-core/error-handler/configs/eslint.config.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.js
 // @(#) : ESLint flat config for TypeScript workspace
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/error-handler/configs/eslint.config.typed.js
+++ b/packages/@esta-core/error-handler/configs/eslint.config.typed.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.typed.js
 // @(#) : eslint float config for type check
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/error-handler/configs/secretlint.config.yaml
+++ b/packages/@esta-core/error-handler/configs/secretlint.config.yaml
@@ -1,7 +1,7 @@
 # src: /shared/configs/secretlint.config.yaml
 # @(#) : secretlintrc
 #
-# Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+# Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 #
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT

--- a/packages/@esta-core/error-handler/configs/tsup.config.module.ts
+++ b/packages/@esta-core/error-handler/configs/tsup.config.module.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.module.ts
 // @(#) : tsup config for esm module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/error-handler/configs/tsup.config.ts
+++ b/packages/@esta-core/error-handler/configs/tsup.config.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.ts
 // @(#) : tsup config for CommonJS module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/error-handler/configs/vitest.config.ci.ts
+++ b/packages/@esta-core/error-handler/configs/vitest.config.ci.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.ci.ts
 // @(#) : vitest config for integration test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/error-handler/configs/vitest.config.unit.ts
+++ b/packages/@esta-core/error-handler/configs/vitest.config.unit.ts
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@esta-core/error-handler/configs/vitest.config.unit.ts
+++ b/packages/@esta-core/error-handler/configs/vitest.config.unit.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.unit.ts
 // @(#) : vitest config for unit test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/error-handler/tsconfig.json
+++ b/packages/@esta-core/error-handler/tsconfig.json
@@ -28,8 +28,7 @@
     "baseUrl": "./",
     "paths": {
       "@/*": [
-        "src/*",
-        "shared/*"
+        "./src/*"
       ]
     },
     // types

--- a/packages/@esta-core/feature-flags/configs/eslint.config.js
+++ b/packages/@esta-core/feature-flags/configs/eslint.config.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.js
 // @(#) : ESLint flat config for TypeScript workspace
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/feature-flags/configs/eslint.config.typed.js
+++ b/packages/@esta-core/feature-flags/configs/eslint.config.typed.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.typed.js
 // @(#) : eslint float config for type check
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/feature-flags/configs/secretlint.config.yaml
+++ b/packages/@esta-core/feature-flags/configs/secretlint.config.yaml
@@ -1,7 +1,7 @@
 # src: /shared/configs/secretlint.config.yaml
 # @(#) : secretlintrc
 #
-# Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+# Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 #
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT

--- a/packages/@esta-core/feature-flags/configs/tsup.config.module.ts
+++ b/packages/@esta-core/feature-flags/configs/tsup.config.module.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.module.ts
 // @(#) : tsup config for esm module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/feature-flags/configs/tsup.config.ts
+++ b/packages/@esta-core/feature-flags/configs/tsup.config.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.ts
 // @(#) : tsup config for CommonJS module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/feature-flags/configs/vitest.config.ci.ts
+++ b/packages/@esta-core/feature-flags/configs/vitest.config.ci.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.ci.ts
 // @(#) : vitest config for integration test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-core/feature-flags/configs/vitest.config.unit.ts
+++ b/packages/@esta-core/feature-flags/configs/vitest.config.unit.ts
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@esta-core/feature-flags/configs/vitest.config.unit.ts
+++ b/packages/@esta-core/feature-flags/configs/vitest.config.unit.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.unit.ts
 // @(#) : vitest config for unit test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
@@ -34,7 +34,6 @@ export default mergeConfig(baseConfig, {
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '../src'),
-      '@shared': path.resolve(__dirname, '../shared/'),
     },
   },
 });

--- a/packages/@esta-core/feature-flags/tsconfig.json
+++ b/packages/@esta-core/feature-flags/tsconfig.json
@@ -28,8 +28,7 @@
     "baseUrl": "./",
     "paths": {
       "@/*": [
-        "src/*",
-        "shared/*"
+        "./src/*"
       ]
     },
     // types

--- a/packages/@esta-system/exit-status/configs/eslint.config.js
+++ b/packages/@esta-system/exit-status/configs/eslint.config.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.js
 // @(#) : ESLint flat config for TypeScript workspace
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-system/exit-status/configs/eslint.config.typed.js
+++ b/packages/@esta-system/exit-status/configs/eslint.config.typed.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.typed.js
 // @(#) : eslint float config for type check
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-system/exit-status/configs/secretlint.config.yaml
+++ b/packages/@esta-system/exit-status/configs/secretlint.config.yaml
@@ -1,7 +1,7 @@
 # src: /shared/configs/secretlint.config.yaml
 # @(#) : secretlintrc
 #
-# Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+# Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 #
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT

--- a/packages/@esta-system/exit-status/configs/tsup.config.module.ts
+++ b/packages/@esta-system/exit-status/configs/tsup.config.module.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.module.ts
 // @(#) : tsup config for esm module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-system/exit-status/configs/tsup.config.ts
+++ b/packages/@esta-system/exit-status/configs/tsup.config.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.ts
 // @(#) : tsup config for CommonJS module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-system/exit-status/configs/vitest.config.ci.ts
+++ b/packages/@esta-system/exit-status/configs/vitest.config.ci.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.ci.ts
 // @(#) : vitest config for integration test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-system/exit-status/configs/vitest.config.unit.ts
+++ b/packages/@esta-system/exit-status/configs/vitest.config.unit.ts
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@esta-system/exit-status/configs/vitest.config.unit.ts
+++ b/packages/@esta-system/exit-status/configs/vitest.config.unit.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.unit.ts
 // @(#) : vitest config for unit test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
@@ -34,7 +34,6 @@ export default mergeConfig(baseConfig, {
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '../src'),
-      '@shared': path.resolve(__dirname, '../shared/'),
     },
   },
 });

--- a/packages/@esta-system/exit-status/tsconfig.json
+++ b/packages/@esta-system/exit-status/tsconfig.json
@@ -28,11 +28,7 @@
     "baseUrl": "./",
     "paths": {
       "@/*": [
-        "src/*",
-        "shared/*"
-      ],
-      "@shared/*": [
-        "shared/*"
+        "./src/*"
       ]
     },
     // types

--- a/packages/@esta-utils/command-runner/configs/commitlint.config.ts
+++ b/packages/@esta-utils/command-runner/configs/commitlint.config.ts
@@ -1,7 +1,7 @@
 // src: commitlint.config.ts
 // @(#) : commitlint configuration for this workspace
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/command-runner/configs/eslint.config.js
+++ b/packages/@esta-utils/command-runner/configs/eslint.config.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.js
 // @(#) : ESLint flat config for TypeScript workspace
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/command-runner/configs/eslint.config.typed.js
+++ b/packages/@esta-utils/command-runner/configs/eslint.config.typed.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.typed.js
 // @(#) : eslint float config for type check
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/command-runner/configs/tsup.config.module.ts
+++ b/packages/@esta-utils/command-runner/configs/tsup.config.module.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.module.ts
 // @(#) : tsup config for esm module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/command-runner/configs/tsup.config.ts
+++ b/packages/@esta-utils/command-runner/configs/tsup.config.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.ts
 // @(#) : tsup config for CommonJS module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/command-runner/configs/vitest.config.ci.ts
+++ b/packages/@esta-utils/command-runner/configs/vitest.config.ci.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.ci.ts
 // @(#) : vitest config for integration test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/command-runner/configs/vitest.config.unit.ts
+++ b/packages/@esta-utils/command-runner/configs/vitest.config.unit.ts
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@esta-utils/command-runner/configs/vitest.config.unit.ts
+++ b/packages/@esta-utils/command-runner/configs/vitest.config.unit.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.unit.ts
 // @(#) : vitest config for unit test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/command-runner/tsconfig.json
+++ b/packages/@esta-utils/command-runner/tsconfig.json
@@ -17,15 +17,16 @@
     "lib",
     "module",
     "node_modules",
-    ".cache"
+    ".cache",
+    "temp"
   ],
   "compilerOptions": {
     // directories
     "outDir": "lib",
     "rootDir": ".",
     "paths": {
-      "@": [
-        "./src/"
+      "@/*": [
+        "./src/*"
       ]
     },
     // alias

--- a/packages/@esta-utils/config-loader/configs/eslint.config.js
+++ b/packages/@esta-utils/config-loader/configs/eslint.config.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.js
 // @(#) : ESLint flat config for TypeScript workspace
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/config-loader/configs/eslint.config.typed.js
+++ b/packages/@esta-utils/config-loader/configs/eslint.config.typed.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.typed.js
 // @(#) : eslint float config for type check
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/config-loader/configs/tsup.config.module.ts
+++ b/packages/@esta-utils/config-loader/configs/tsup.config.module.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.module.ts
 // @(#) : tsup config for esm module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/config-loader/configs/tsup.config.ts
+++ b/packages/@esta-utils/config-loader/configs/tsup.config.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.ts
 // @(#) : tsup config for CommonJS module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/config-loader/configs/vitest.config.ci.ts
+++ b/packages/@esta-utils/config-loader/configs/vitest.config.ci.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.ci.ts
 // @(#) : vitest config for integration test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/config-loader/configs/vitest.config.unit.ts
+++ b/packages/@esta-utils/config-loader/configs/vitest.config.unit.ts
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@esta-utils/config-loader/configs/vitest.config.unit.ts
+++ b/packages/@esta-utils/config-loader/configs/vitest.config.unit.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.unit.ts
 // @(#) : vitest config for unit test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
@@ -34,7 +34,6 @@ export default mergeConfig(baseConfig, {
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '../src'),
-      '@shared': path.resolve(__dirname, '../shared/'),
     },
   },
 });

--- a/packages/@esta-utils/config-loader/src/__tests__/configSearchDirs.spec.ts
+++ b/packages/@esta-utils/config-loader/src/__tests__/configSearchDirs.spec.ts
@@ -11,7 +11,7 @@ import process from 'process';
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { TEstaSearchConfigFileType } from '@shared/types/common.types';
+import { TEstaSearchConfigFileType } from '../../shared/types/common.types';
 
 import { getDelimiter } from '@esta-utils/get-platform';
 // vitest

--- a/packages/@esta-utils/config-loader/src/__tests__/findConfigFile.spec.ts
+++ b/packages/@esta-utils/config-loader/src/__tests__/findConfigFile.spec.ts
@@ -13,7 +13,7 @@ import process from 'process';
 // vitest
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { TEstaSearchConfigFileType } from '@shared/types/common.types';
+import { TEstaSearchConfigFileType } from '../../shared/types/common.types';
 
 // test unit
 

--- a/packages/@esta-utils/config-loader/src/configSearchDirs.ts
+++ b/packages/@esta-utils/config-loader/src/configSearchDirs.ts
@@ -11,7 +11,7 @@ import * as os from 'os';
 import process from 'process';
 
 // --- internal libs
-import { TEstaSearchConfigFileType } from '@shared/types/common.types';
+import { TEstaSearchConfigFileType } from '../shared/types/common.types';
 
 import { getDelimiter } from '@esta-utils/get-platform';
 // --- types

--- a/packages/@esta-utils/config-loader/src/findConfigFile.ts
+++ b/packages/@esta-utils/config-loader/src/findConfigFile.ts
@@ -10,8 +10,8 @@ import * as fs from 'fs';
 import { resolve } from 'path';
 
 // types
-import type { TEstaSearchConfigFileType } from '@shared/types/common.types';
-import { EstaSupportedExtensions } from '@shared/types/configFile.types';
+import type { TEstaSearchConfigFileType } from '../shared/types/common.types';
+import { EstaSupportedExtensions } from '../shared/types/configFile.types';
 
 // modules
 import { configSearchDirs } from './configSearchDirs';

--- a/packages/@esta-utils/config-loader/src/index.ts
+++ b/packages/@esta-utils/config-loader/src/index.ts
@@ -5,11 +5,8 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// constants
-export * from '@shared/constants';
-
 // types
-export * from '@shared/types';
+export * from '../shared/types';
 
 // modules
 export * from './findConfigFile';
@@ -24,7 +21,7 @@ import { normalizeExtension, parseConfig } from './parseConfig';
 // types
 
 // constants
-import { EstaExtensionToFileTypeMap, EstaSupportedExtensions } from '@shared/types';
+import { EstaExtensionToFileTypeMap, EstaSupportedExtensions } from '../shared/types';
 
 // default export
 const configLoader = {

--- a/packages/@esta-utils/config-loader/src/loadConfig.ts
+++ b/packages/@esta-utils/config-loader/src/loadConfig.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import { extname } from 'path';
 
 // types
-import { TEstaSearchConfigFileType } from '@shared/types/common.types';
+import { TEstaSearchConfigFileType } from '../shared/types/common.types';
 
 // modules
 import { findConfigFile } from './findConfigFile';

--- a/packages/@esta-utils/config-loader/src/parseConfig.ts
+++ b/packages/@esta-utils/config-loader/src/parseConfig.ts
@@ -11,7 +11,7 @@ import {
   EstaExtensionToFileTypeMap,
   TEstaConfigFileType,
   type TEstaSupportedExtension,
-} from '@shared/types/configFile.types';
+} from '../shared/types/configFile.types';
 
 // parser
 import { parseJsonc } from './parser/parseJsonc';

--- a/packages/@esta-utils/config-loader/tests/e2e/loadConfig.spec.ts
+++ b/packages/@esta-utils/config-loader/tests/e2e/loadConfig.spec.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from 'vitest';
 
 // types
-import { TEstaSearchConfigFileType } from '@shared/types/common.types';
+import { TEstaSearchConfigFileType } from '../../shared/types/common.types';
 
 // test unit
 import { loadConfig } from '@/loadConfig';

--- a/packages/@esta-utils/config-loader/tsconfig.json
+++ b/packages/@esta-utils/config-loader/tsconfig.json
@@ -17,7 +17,8 @@
     "lib",
     "module",
     "node_modules",
-    ".cache"
+    ".cache",
+    "temp"
   ],
   "compilerOptions": {
     // directories
@@ -28,10 +29,7 @@
     // "paths": {},
     "paths": {
       "@/*": [
-        "src/*"
-      ],
-      "@shared/*": [
-        "shared/*"
+        "./src/*"
       ]
     },
     // types

--- a/packages/@esta-utils/get-platform/configs/commitlint.config.ts
+++ b/packages/@esta-utils/get-platform/configs/commitlint.config.ts
@@ -1,7 +1,7 @@
 // src: commitlint.config.ts
 // @(#) : commitlint configuration for this workspace
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/get-platform/configs/eslint.config.js
+++ b/packages/@esta-utils/get-platform/configs/eslint.config.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.js
 // @(#) : ESLint flat config for TypeScript workspace
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/get-platform/configs/eslint.config.typed.js
+++ b/packages/@esta-utils/get-platform/configs/eslint.config.typed.js
@@ -1,7 +1,7 @@
 // src: configs/eslint.config.typed.js
 // @(#) : eslint float config for type check
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/get-platform/configs/tsup.config.module.ts
+++ b/packages/@esta-utils/get-platform/configs/tsup.config.module.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.module.ts
 // @(#) : tsup config for esm module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/get-platform/configs/tsup.config.ts
+++ b/packages/@esta-utils/get-platform/configs/tsup.config.ts
@@ -1,7 +1,7 @@
 // src: configs/tsup.config.ts
 // @(#) : tsup config for CommonJS module
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT

--- a/packages/@esta-utils/get-platform/configs/vitest.config.ci.ts
+++ b/packages/@esta-utils/get-platform/configs/vitest.config.ci.ts
@@ -1,7 +1,7 @@
-// src: ./configs/vitest.config.unit.ts
-// @(#) : vitest config for unit test
+// src: ./configs/vitest.config.ci.ts
+// @(#) : vitest config for integration test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'tests/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/ci'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/ci/'),
     },
   },
   resolve: {

--- a/packages/@esta-utils/get-platform/configs/vitest.config.unit.ts
+++ b/packages/@esta-utils/get-platform/configs/vitest.config.unit.ts
@@ -1,7 +1,7 @@
 // src: ./configs/vitest.config.unit.ts
 // @(#) : vitest config for unit test
 //
-// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
@@ -34,7 +34,6 @@ export default mergeConfig(baseConfig, {
   resolve: {
     alias: {
       '@': path.resolve(__dirname, '../src'),
-      '@shared': path.resolve(__dirname, '../shared'),
     },
   },
 });

--- a/packages/@esta-utils/get-platform/configs/vitest.config.unit.ts
+++ b/packages/@esta-utils/get-platform/configs/vitest.config.unit.ts
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@esta-utils/get-platform/shared/constants/platform.ts
+++ b/packages/@esta-utils/get-platform/shared/constants/platform.ts
@@ -6,7 +6,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { PLATFORM_TYPE } from '@shared/types';
+import { PLATFORM_TYPE } from '../types';
 
 /**
  * Node.js os.platform()の値とPLATFORM_TYPEのマッピング

--- a/packages/@esta-utils/get-platform/src/__tests__/exports.spec.ts
+++ b/packages/@esta-utils/get-platform/src/__tests__/exports.spec.ts
@@ -9,9 +9,9 @@
 // vitest
 import { describe, expect, it } from 'vitest';
 // constants
-import { PATH_DELIMITER, PLATFORM_MAP } from '@shared/constants';
+import { PATH_DELIMITER, PLATFORM_MAP } from '../../shared/constants';
 // types
-import { PLATFORM_TYPE } from '@shared/types';
+import { PLATFORM_TYPE } from '../../shared/types';
 // test target
 import {
   getDelimiter,

--- a/packages/@esta-utils/get-platform/src/__tests__/getPlatform.spec.ts
+++ b/packages/@esta-utils/get-platform/src/__tests__/getPlatform.spec.ts
@@ -17,8 +17,8 @@ vi.mock('os', () => ({
 // lib
 import * as os from 'os';
 // constants
-import type { TPlatformKey } from '@shared/constants';
-import { PLATFORM_TYPE } from '@shared/types';
+import type { TPlatformKey } from '../../shared/constants';
+import { PLATFORM_TYPE } from '../../shared/types';
 // test target
 import { clearPlatformCache, getPlatform } from '@/getPlatform';
 

--- a/packages/@esta-utils/get-platform/src/__tests__/utils.spec.ts
+++ b/packages/@esta-utils/get-platform/src/__tests__/utils.spec.ts
@@ -9,7 +9,7 @@
 // vitest
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 // constants
-import { PATH_DELIMITER } from '@shared/constants';
+import { PATH_DELIMITER } from '../../shared/constants';
 // test target
 import { getDelimiter } from '@/getPlatform';
 

--- a/packages/@esta-utils/get-platform/src/getPlatform.ts
+++ b/packages/@esta-utils/get-platform/src/getPlatform.ts
@@ -9,10 +9,10 @@
 // lib
 import * as os from 'os';
 // constants
-import { PATH_DELIMITER, PLATFORM_MAP } from '@shared/constants';
-import { PLATFORM_TYPE } from '@shared/types';
+import { PATH_DELIMITER, PLATFORM_MAP } from '../shared/constants';
+import { PLATFORM_TYPE } from '../shared/types';
 // types
-import type { TPlatformKey } from '@shared/constants';
+import type { TPlatformKey } from '../shared/constants';
 
 // キャッシュ用の変数
 let platformCache: PLATFORM_TYPE | undefined;

--- a/packages/@esta-utils/get-platform/src/index.ts
+++ b/packages/@esta-utils/get-platform/src/index.ts
@@ -8,7 +8,7 @@
 
 // import all
 import { getDelimiter, getPlatform } from '@/getPlatform';
-import { PLATFORM_TYPE } from '@shared/types';
+import { PLATFORM_TYPE } from '../shared/types';
 
 // namespace
 const estaUtils = {
@@ -20,6 +20,6 @@ const estaUtils = {
 // --- export
 // named export
 export * from '@/getPlatform';
-export * from '@shared/constants';
-export * from '@shared/types';
+export * from '../shared/constants';
+export * from '../shared/types';
 export { estaUtils };

--- a/packages/@esta-utils/get-platform/tests/e2e/platformIntegration.spec.ts
+++ b/packages/@esta-utils/get-platform/tests/e2e/platformIntegration.spec.ts
@@ -9,7 +9,7 @@
 // vitest
 import { describe, expect, it } from 'vitest';
 // types
-import { PLATFORM_TYPE } from '@shared/types';
+import { PLATFORM_TYPE } from '../../shared/types';
 // test target
 import {
   estaUtils,

--- a/packages/@esta-utils/get-platform/tsconfig.json
+++ b/packages/@esta-utils/get-platform/tsconfig.json
@@ -18,7 +18,8 @@
     "lib",
     "module",
     "node_modules",
-    ".cache"
+    ".cache",
+    "temp"
   ],
   "compilerOptions": {
     // directories
@@ -28,12 +29,7 @@
     "baseUrl": "./",
     "paths": {
       "@/*": [
-        "src/*",
-        "src/*/index"
-      ],
-      "@shared/*": [
-        "shared/*",
-        "shared/*/index"
+        "./src/*"
       ]
     },
     // types

--- a/packages/@esta-utils/utils/configs/vitest.config.unit.ts
+++ b/packages/@esta-utils/utils/configs/vitest.config.unit.ts
@@ -1,4 +1,4 @@
-// src: packages/@esta-utils/utils/configs/vitest.config.unit.ts
+// src: ./configs/vitest.config.unit.ts
 // @(#) : vitest config for unit test
 //
 // Copyright (c) 2025 atsushifx <https://github.com/atsushifx>

--- a/packages/@esta-utils/utils/configs/vitest.config.unit.ts
+++ b/packages/@esta-utils/utils/configs/vitest.config.unit.ts
@@ -28,7 +28,7 @@ export default mergeConfig(baseConfig, {
       'src/**/*.spec.ts',
     ],
     caches: {
-      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit'),
+      dir: path.resolve(__dirname, '../../../../.cache/vitest-cache/unit/'),
     },
   },
   resolve: {

--- a/packages/@esta-utils/utils/tsconfig.json
+++ b/packages/@esta-utils/utils/tsconfig.json
@@ -17,7 +17,8 @@
     "lib",
     "module",
     "node_modules",
-    ".cache"
+    ".cache",
+    "temp"
   ],
   "compilerOptions": {
     // directories
@@ -25,7 +26,11 @@
     "rootDir": "./src",
     // alias
     "baseUrl": "./",
-    // "paths": {},
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
     // types
     // cache
     "tsBuildInfoFile": ".cache/tsbuild-cache/tsbuildinfo"

--- a/shared/packages/constants/tsconfig.json
+++ b/shared/packages/constants/tsconfig.json
@@ -15,7 +15,8 @@
     "lib",
     "module",
     "node_modules",
-    ".cache"
+    ".cache",
+    "temp"
   ],
   "compilerOptions": {
     // directories

--- a/shared/packages/types/tsconfig.json
+++ b/shared/packages/types/tsconfig.json
@@ -15,7 +15,8 @@
     "lib",
     "module",
     "node_modules",
-    ".cache"
+    ".cache",
+    "temp"
   ],
   "compilerOptions": {
     // directories


### PR DESCRIPTION
## ✨ Overview

複数パッケージにまたがって存在していたconfigのばらつきを整理し、共通化の方針を強化しました。  
また、これまで `@shared` で参照していたモジュールについては、相対パスに統一することで、依存関係の明確化と環境依存性の排除を図っています。

---

## 🔧 Changes

- [x] 各パッケージに存在していた独自の `tsconfig` / `eslint` 等を整理・共通化
- [x] `@shared` パスエイリアスの使用を廃止し、相対パスへ統一
- [x] import構文のリファクタリングによるパスの明示化
- [x] configの統一に伴う redundant な設定の削除

---

## 📂 Related Issues

> None

---

## ✅ Checklist

- [x] Lint checks pass (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [ ] Documentation is updated（特にパスエイリアス削除に関して注意書きの追記が必要）
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

- 今後 `@shared` を前提とした記述はすべて非推奨とし、READMEや開発ガイドラインにも反映予定です。
- IDE側のパス補完に影響がある可能性があるため、各開発者は `.vscode/settings.json` の確認を推奨します。
