### PR TITLE
docs(specs): 仕様書ルールおよび構造規約の追加

### DIFF
--- a/docs/specs/@esta-actions-tools-installer.spec.md
+++ b/docs/specs/@esta-actions-tools-installer.spec.md
@@ -1,14 +1,25 @@
-<!--
-  src: docs/specs/esta-executor-specs.md
+---
+header:
+  - src: docs/specs/@esta-actions-tools-installer.spec.md
+  - @(#) : ESTA Actions Tools Installer framework
+title: 📦 ツールインストーラー統合実行仕様書（@esta-actions/tools-installer）
+version: 1.0.0
+created: 2025-07-14
+updated: 2025-07-14
+authors:
+  - 🧠 つむぎ（executor分離設計）
+  - 🧁 小紅（実行環境統合設計）
+  - ⚙️ エルファ（GitHub Actions統合）
+  - 👤 atsushifx（全体設計・仕様確定）
+changes:
+  - 2025-07-14: フロントマター追加とドキュメント統一
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
+---
 
-  Copyright (c) 2025 atsushifx
-  This software is released under the MIT License.
-  https://opensource.org/licenses/MIT
--->
-
-# 📘 `@esta/esta-executor` 設計仕様書
-
-## 1. 概要
+## 概要
 
 `@esta/esta-executor` は、複数の実行環境（CLI、GitHub Actions、Deno など）に対応した「統一的な実行制御フレームワーク」です。
 

--- a/docs/specs/@esta-core--tools-config.spec.md
+++ b/docs/specs/@esta-core--tools-config.spec.md
@@ -1,24 +1,21 @@
-<!--
-  src: docs/specs/@esta-core--tools-config.spec.md
-
-  Copyright (c) 2025 atsushifx
-  This software is released under the MIT License.
-  https://opensource.org/licenses/MIT
--->
-
 ---
+header:
+  - src: docs/specs/@esta-core--tools-config.spec.md
+  - @(#) : ESTA Install Tools configuration reader
 title: 🔧 ツール設定統合管理仕様書（@esta-core/tools-config）
 version: 1.0.0
-created: 2025-01-14
-updated: 2025-01-14
+created: 2025-07-14
+updated: 2025-07-14
 authors:
   - 🤖 Claude（初期設計・API仕様策定）
   - 👤 atsushifx（要件定義・仕様確定）
 changes:
-  - 2025-01-14: 初回作成（GitHub issue #94 対応）
+  - 2025-07-14: 初回作成（GitHub issue #94 対応）
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
 ---
-
-# @esta-core/tools-config パッケージ仕様書
 
 ## 概要
 
@@ -35,7 +32,7 @@ changes:
 
 ### 1. 設定ファイル読み込み
 
-- TypeScript、JSON、YAML、JavaScript形式の設定ファイルをサポート
+- TypeScript、JSON、YAML、JavaScript 形式の設定ファイルをサポート
 - 複数の設定ファイルのマージ機能
 - 設定ファイルの自動検出機能
 
@@ -48,7 +45,7 @@ changes:
 ### 3. 型安全性
 
 - `valibot`による設定検証
-- TypeScript型定義の完全なサポート
+- TypeScript 型定義の完全なサポート
 - ランタイム時の型チェック
 
 ## API仕様
@@ -57,7 +54,7 @@ changes:
 
 #### `getTool(id: string): ToolEntry | undefined`
 
-指定されたIDのツール設定を取得します。
+指定された ID のツール設定を取得します。
 
 **パラメータ:**
 

--- a/docs/specs/@esta-core-error-handler.spec.md
+++ b/docs/specs/@esta-core-error-handler.spec.md
@@ -1,23 +1,24 @@
-<!--
-  src: docs/specs/error-handler-specs.md
-  Copyright (c) 2025 atsushifx
-  This software is released under the MIT License.
-  https://opensource.org/licenses/MIT
--->
-
 ---
+header:
+  - src: docs/specs/@esta-core-error-handler.spec.md
+  - @(#) : ESTA Core error handling framework
 title: 📘 エラーハンドリング統一仕様書（@esta-core/error-handler）
 version: 1.2.0
 created: 2025-07-09
-updated: 2025-07-11
+updated: 2025-07-14
 authors:
   - 🧠 つむぎ（設計統一・exec 分離提案）
   - 🧁 小紅（例示＆分岐設計）
   - ⚙️ エルファ（FeatureFlag 実装＆fatal 設計）
+  - 👤 atsushifx（全体設計・仕様確定）
 changes:
-  - ExitCode定数を共通定数(@shared/constants/exitCode)に移動
-  - POSIX準拠の終了コード体系を統一
-  - ExitCodeErrorMessage定数を追加
+  - 2025-07-14: フロントマター追加とドキュメント統一
+  - 2025-07-11: ExitCode定数を共通定数(@shared/constants/exitCode)に移動
+  - 2025-07-09: POSIX準拠の終了コード体系を統一、ExitCodeErrorMessage定数を追加
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
 ---
 
 ## 概要
@@ -26,24 +27,24 @@ GitHub Actions と CLI の統一されたエラーハンドリングを提供す
 
 ### 主要機能
 
-- **ExitError クラス** - 終了コードと致命性フラグを持つ統一エラー
-- **errorExit 関数** - 非致命的エラー終了（ログ記録 + ExitError スロー）
-- **fatalExit 関数** - 致命的エラー終了（ログ記録 + 致命的 ExitError スロー）
-- **handleExitError 関数** - ExitError を適切に処理する共通ハンドラ
-- **統一された終了コード** - POSIX準拠の終了コード体系
+- ExitError クラス - 終了コードと致命性フラグを持つ統一エラー
+- errorExit 関数 - 的エラー終了（ログ記録 + ExitError スロー）
+- fatalExit 関数 - 致命的エラー終了（ログ記録 + 致命的 ExitError スロー）
+- handleExitError 関数 - ExitError を適切に処理する共通ハンドラ
+- 統一された終了コード - POSIX 準拠の終了コード体系
 
 ---
 
 ## パッケージ情報
 
-- **パッケージ名**: `@esta-core/error-handler`
-- **バージョン**: 0.0.0
-- **ライセンス**: MIT
-- **依存関係**:
-  - `@actions/core` - GitHub Actions統合
+- パッケージ名: `@esta-core/error-handler`
+- バージョン: 0.0.0
+- ライセンス: MIT
+- 依存関係:
+  - `@actions/core` - GitHub Actions 統合
   - `@agla-utils/ag-logger` - ログ機能
   - `@esta-core/feature-flags` - 実行環境判定
-  - `@shared/constants` - 共通定数（ExitCode等）
+  - `@shared/constants` - 共通定数 (ExitCode 等)
 
 ---
 
@@ -76,8 +77,8 @@ GitHub Actions と CLI の統一されたエラーハンドリングを提供す
 
 **定数の定義場所**:
 
-- **共通定数**: `@shared/constants` - POSIX準拠の統一定義
-- **インポート**: `import { ExitCode } from '@shared/constants'` で使用
+- 共通定数: `@shared/constants` - POSIX 準拠の統一定義
+- インポート: `import { ExitCode } from '@shared/constants'` で使用
 
 ---
 
@@ -130,7 +131,7 @@ export const errorExit = (
 **動作:**
 
 1. ログメッセージをフォーマット
-2. ERRORレベルでログ記録
+2. ERROR レベルでログ記録
 3. ExitError（fatal=false）をスロー
 
 ### fatalExit 関数
@@ -157,12 +158,12 @@ export const fatalExit = (
 **動作:**
 
 1. ログメッセージをフォーマット
-2. FATALレベルでログ記録
+2. FATAL レベルでログ記録
 3. ExitError（fatal=true）をスロー
 
 ### handleExitError 関数
 
-ExitErrorを適切に処理して終了します。
+ExitError を適切に処理して終了します。
 
 ```typescript
 export const handleExitError = (err: ExitError): void => {
@@ -179,12 +180,12 @@ export const handleExitError = (err: ExitError): void => {
 
 **パラメータ:**
 
-- `err`: 処理するExitErrorインスタンス
+- `err`: 処理する ExitError インスタンス
 
 **動作:**
 
-- GitHub Actions環境: `core.setFailed()`でエラー報告
-- CLI環境: `process.exit()`で終了
+- GitHub Actions 環境: `core.setFailed()`でエラー報告
+- CLI 環境: `process.exit()`で終了
 
 ---
 
@@ -210,7 +211,7 @@ export const formatErrorMessage = (
 
 **フォーマット例:**
 
-```
+```bash
 [ERROR(13)] Invalid command line arguments: 引数が必要です in main
 [FATAL(11)] Configuration file not found: CONFIG_PATHが未設定です in validateConfig
 ```
@@ -225,7 +226,8 @@ export const getExitCodeMessage = (code: TExitCode): string => {
 };
 ```
 
-**注意**: `ExitCodeErrorMessage` は `@shared/constants` から提供されます。
+> 注意:
+> `ExitCodeErrorMessage` は `@shared/constants` から提供されます。
 
 ### 呼び出し元情報の取得
 
@@ -235,7 +237,7 @@ export const getExitCodeMessage = (code: TExitCode): string => {
 
 ## ファイル構成
 
-```
+```bash
 packages/@esta-core/error-handler/
 ├── package.json
 ├── src/
@@ -263,7 +265,7 @@ packages/@esta-core/error-handler/
 
 ## 使用例
 
-### CLIアプリでの使用
+### CLIアプリケーションでの使用
 
 ```typescript
 import { errorExit, ExitError, handleExitError } from '@esta-core/error-handler';
@@ -342,12 +344,12 @@ const processFile = async (filePath: string) => {
 
 ### 単体テスト
 
-- **ExitError.spec.ts**: ExitErrorクラスのテスト
-- **errorExit.spec.ts**: errorExit関数のテスト
-- **fatalExit.spec.ts**: fatalExit関数のテスト
-- **handleExitError.spec.ts**: handleExitError関数のテスト
+- ExitError.spec.ts: ExitError クラスのテスト
+- errorExit.spec.ts: errorExit 関数のテスト
+- fatalExit.spec.ts: fatalExit 関数のテスト
+- handleExitError.spec.ts: handleExitError 関数のテスト
 
 ### E2Eテスト
 
-- **errorExit.spec.ts**: errorExit関数の統合テスト
-- **fatalExit.spec.ts**: fatalExit関数の統合テスト
+- errorExit.spec.ts: errorExit 関数の統合テスト
+- fatalExit.spec.ts: fatalExit 関数の統合テスト

--- a/docs/specs/@esta-core-esta-config.spec.md
+++ b/docs/specs/@esta-core-esta-config.spec.md
@@ -1,13 +1,25 @@
-<!--
-  src: docs/specs/esta-config-spec.md
-  Copyright (c) 2025 atsushifx
-  This software is released under the MIT License.
-  https://opensource.org/licenses/MIT
--->
+---
+header:
+  - src: docs/specs/@esta-core-esta-config.spec.md
+  - @(#) : ESTA Core configuration management module
+title: 📜 統合設定管理モジュール仕様書（@esta-core/esta-config）
+version: 1.0.0
+created: 2025-07-14
+updated: 2025-07-14
+authors:
+  - 🧠 つむぎ（設計統一・モジュラー設計）
+  - 🧁 小紅（GitHub Actions特化設計）
+  - ⚙️ エルファ（スキーマ検証実装）
+  - 👤 atsushifx（全体設計・仕様確定）
+changes:
+  - 2025-07-14: フロントマター追加とドキュメント統一
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
+---
 
-# 📘 @esta-core/esta-config モジュール設計仕様書
-
-## 1. 概要
+## 概要
 
 `@esta-core/esta-config` は、ESTA プロジェクトにおける統一的な設定管理モジュールです。**GitHub Actions での使用をメイン**とし、CLI ツールとの共通設定処理を提供します。設定の重複・不整合を解決し、シンプルで実用的な設計を目指します。
 

--- a/docs/specs/@esta-core-feature-flags.spec.md
+++ b/docs/specs/@esta-core-feature-flags.spec.md
@@ -1,14 +1,26 @@
-<!--
-  src: docs/specs/feature-flags.spec.md
+---
+header:
+  - src: docs/specs/@esta-core-feature-flags.spec.md
+  - @(#) : ESTA Core feature flags management module
+title: 🏳️ フィーチャーフラグモジュール仕様書（@esta-core/feature-flags）
+version: 1.2.0
+created: 2025-07-09
+updated: 2025-07-14
+authors:
+  - 🧠 つむぎ（設計統一・グローバルフラグ設計）
+  - 🧁 小紅（実行環境判定設計）
+  - ⚙️ エルファ（コンテキスト実装）
+  - 👤 atsushifx（全体設計・仕様確定）
+changes:
+  - 2025-07-14: フロントマター追加とドキュメント統一
+  - 2025-07-09: 初回作成
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
+---
 
-  Copyright (c) 2025 atsushifx
-  This software is released under the MIT License.
-  https://opensource.org/licenses/MIT
--->
-
-# 📘 FeatureFlags モジュール設計仕様書
-
-## 1. 概要
+## 概要
 
 <!-- textlint-disable ja-technical-writing/sentence-length -->
 

--- a/docs/specs/@esta-system-exit-status.spec.md
+++ b/docs/specs/@esta-system-exit-status.spec.md
@@ -1,4 +1,22 @@
-# @esta-system/exit-status 仕様書
+---
+header:
+  - src: docs/specs/@esta-system-exit-status.spec.md
+  - @(#) : ESTA System exit status management
+title: 🚪 終了ステータス管理仕様書（@esta-system/exit-status）
+version: 1.0.0
+created: 2025-07-14
+updated: 2025-07-14
+authors:
+  - 🧠 つむぎ（シングルトン設計）
+  - ⚙️ エルファ（フェイルファスト動作実装）
+  - 👤 atsushifx（全体設計・仕様確定）
+changes:
+  - 2025-07-14: フロントマター追加とドキュメント統一
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
+---
 
 ## 概要
 
@@ -7,37 +25,39 @@
 
 ## パッケージ情報
 
-- **パッケージ名**: `@esta-system/exit-status`
-- **バージョン**: 0.0.0
-- **タイプ**: ES Module (dual package)
-- **依存関係**: `@esta-core/error-handler`
+- パッケージ名: `@esta-system/exit-status`
+- バージョン: 0.0.0
+- タイプ: ES Module (dual package)
+- 依存関係: `@esta-core/error-handler`
 
 ## API 仕様
+
+<!-- markdownlint-disable no-duplicate-heading -->
 
 ### ExitStatus クラス
 
 #### 概要
 
-static classを使用した終了ステータス管理クラス。
+static class を使用した終了ステータス管理クラス。
 
 #### メソッド
 
 ##### `static set(status: number): void`
 
-**目的**: 終了ステータスを設定する
+目的: 終了ステータスを設定する。
 
-**パラメータ**:
+パラメータ:
 
 - `status` (number): 設定する終了ステータスコード
 
-**動作仕様**:
+動作仕様:
 
 - 正の非ゼロ値のみ受け付ける
 - ゼロ値および負の値は無視される
 - 一度非ゼロ値が設定されると、その後のゼロ値は無視される
 - 複数の非ゼロ値が設定された場合、最後の値が保持される
 
-**例**:
+例:
 
 ```typescript
 ExitStatus.set(1); // ステータスを1に設定
@@ -48,13 +68,13 @@ ExitStatus.set(2); // ステータスを2に設定
 
 ##### `static get(): number`
 
-**目的**: 現在の終了ステータスを取得する
+目的: 現在の終了ステータスを取得。
 
-**戻り値**:
+リターン値:
 
 - `number`: 現在の終了ステータスコード（0=成功、非ゼロ=エラー）
 
-**例**:
+例:
 
 ```typescript
 const status = ExitStatus.get();
@@ -65,21 +85,23 @@ if (status !== 0) {
 
 ##### `static reset(): void`
 
-**目的**: 終了ステータスをゼロ（成功）にリセットする
+目的: 終了ステータスをゼロ (成功) にリセット。
 
-**動作仕様**:
+動作仕様:
 
-- 明示的に終了ステータスを0に設定する
+- 明示的に終了ステータスを 0に設定する
 - 以前に設定された非ゼロ値をクリアする唯一の方法
 - 連続して呼び出しても問題ない
 
-**例**:
+例:
 
 ```typescript
 ExitStatus.set(1); // エラーステータスを設定
 ExitStatus.reset(); // 成功ステータスにクリア
 console.log(ExitStatus.get()); // 出力: 0
 ```
+
+<!-- markdownlint-enable -->
 
 ## 使用例
 
@@ -163,7 +185,7 @@ console.log(`Process completed with status: ${status}`);
 - [x] 非ゼロ値設定後のゼロ値無視
 - [x] 複数非ゼロ値の最後の値保持
 - [x] 負の値の無視
-- [x] ExitCode.SUCCESS定数との連携
+- [x] ExitCode.SUCCESS 定数との連携
 
 ### エッジケーステスト
 

--- a/docs/specs/@esta-utils-command-runner.spec.md
+++ b/docs/specs/@esta-utils-command-runner.spec.md
@@ -1,31 +1,57 @@
-# command-utils Package Specification
+---
+header:
+  - src: docs/specs/@esta-utils-command-runner.spec.md
+  - @(#) : ESTA Utils command execution utilities
+title: 🏃 コマンド実行ユーティリティ仕様書（@esta-utils/command-runner）
+version: 1.0.0
+created: 2025-07-14
+updated: 2025-07-14
+authors:
+  - 🧠 つむぎ（コマンド実行アーキテクチャ）
+  - 🧁 小紅（クロスプラットフォーム対応）
+  - ⚙️ エルファ（シェル統合実装）
+  - 👤 atsushifx（全体設計・仕様確定）
+changes:
+  - 2025-07-14: フロントマター追加とドキュメント統一
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
+---
 
-## Overview
+## 概要
 
-The `@esta-utils/command-utils` package provides a comprehensive set of utilities for safe and reliable command execution in cross-platform environments. This package is designed to handle shell command execution with proper escaping, platform-specific shell management, and command existence checking.
+<!-- textlint-disable ja-technical-writing/sentence-length -->
+<!-- markdownlint-disable line-length -->
+
+The `@esta-utils/command-utils` package provides a comprehensive set of utilities for safe and reliable command execution in cross-platform environments. This package is designed to handle shell command
+execution with proper escaping, platform-specific shell management, and command existence checking.
+
+<!-- markdownlint-disable -->
+<!-- textlint-enable -->
 
 ## Package Information
 
-- **Package Name**: `@esta-utils/command-utils`
-- **Version**: 0.0.0
-- **License**: MIT
-- **Author**: atsushifx
-- **Type**: ESM Module with CommonJS compatibility
+- Package Name: `@esta-utils/command-utils`
+- Version: 0.0.0
+- License: MIT
+- Author: atsushifx
+- Type: ESM Module with CommonJS compatibility
 
 ## Current Implementation Status
 
 ### Existing Features
 
-- ✅ `commandExist`: Command existence checking utility
-- ✅ Platform detection integration with `@esta-utils/get-platform`
-- ✅ Windows and Linux/macOS support
+- `commandExist`: Command existence checking utility
+- Platform detection integration with `@esta-utils/get-platform`
+- Windows and Linux/macOS support
 
 ### Planned Features (To Be Implemented)
 
-- 🔄 `wrapCommand`: Safe command and argument wrapping
-- 🔄 `shellTable`: Platform-specific shell configuration
-- 🔄 `runCommand`: Asynchronous command execution with timeout
-- 🔄 Enhanced `commandExist` using `runCommand`
+- `wrapCommand`: Safe command and argument wrapping
+- `shellTable`: Platform-specific shell configuration
+- `runCommand`: Asynchronous command execution with timeout
+- Enhanced `commandExist` using `runCommand`
 
 ## API Specifications
 
@@ -259,10 +285,10 @@ console.log('All commands completed:', results);
 
 ## Compatibility
 
-- **Node.js**: >= 20
-- **Package Manager**: pnpm >= 10
-- **Platforms**: Windows, Linux, macOS
-- **Module System**: ESM with CommonJS compatibility
+- Node.js: >= 20
+- Package Manager: pnpm >= 10
+- Platforms: Windows, Linux, macOS
+- Module System: ESM with CommonJS compatibility
 
 ## Migration Guide
 
@@ -272,4 +298,8 @@ The existing `commandExist` function will remain backward compatible. New featur
 
 ### Integration with ESTA
 
+<!-- textlint-disable ja-technical-writing/sentence-length -->
+
 This package is designed to support the ESTA GitHub Actions framework, providing safe and reliable command execution for tool installation and automation workflows.
+
+<!-- textlint-enable -->

--- a/docs/specs/@esta-utils-get-platform.spec.md
+++ b/docs/specs/@esta-utils-get-platform.spec.md
@@ -1,4 +1,23 @@
-# get-platform パッケージ仕様書
+---
+header:
+  - src: docs/specs/@esta-utils-get-platform.spec.md
+  - @(#) : ESTA Utils platform detection utilities
+title: 💻 プラットフォーム判定ユーティリティ仕様書（@esta-utils/get-platform）
+version: 1.0.0
+created: 2025-07-14
+updated: 2025-07-14
+authors:
+  - 🧠 つむぎ（プラットフォーム判定アーキテクチャ）
+  - 🧁 小紅（クロスプラットフォーム対応）
+  - ⚙️ エルファ（定数・型定義実装）
+  - 👤 atsushifx（全体設計・仕様確定）
+changes:
+  - 2025-07-14: フロントマター追加とドキュメント統一
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
+---
 
 ## 概要
 
@@ -8,7 +27,7 @@
 
 ### アーキテクチャ
 
-```
+```bash
 src/
 ├── index.ts           # バレルファイル（エクスポート管理）
 ├── getPlatform.ts     # メイン機能実装
@@ -41,15 +60,15 @@ getPlatform(platform?: TPlatformKey | 'unknown' | '', strict?: boolean): PLATFOR
 ```
 
 - デフォルトで`os.platform()`を使用
-- strictモード：未対応プラットフォームで例外スロー
-- 非strictモード：`PLATFORM_TYPE.UNKNOWN`を返却
+- strict モード：未対応プラットフォームで例外スロー
+- 非 strict モード：`PLATFORM_TYPE.UNKNOWN`を返却
 - プラットフォーム情報をキャッシュして重複実行を防止
 
 #### 3. 個別判定関数
 
 ```typescript
 isWindows(): boolean
-isLinux(): boolean  
+isLinux(): boolean
 isMacOS(): boolean
 ```
 
@@ -67,9 +86,9 @@ clearPlatformCache(): void  // 主にテスト用
 
 ### エクスポート構造
 
-- **名前付きエクスポート**: 個別機能
-- **名前空間エクスポート**: `estaUtils`オブジェクト
-- **デフォルトエクスポート**: `getPlatform`関数
+- 名前付きエクスポート: 個別機能
+- 名前空間エクスポート: `estaUtils`オブジェクト
+- デフォルトエクスポート: `getPlatform`関数
 
 ### 型定義
 
@@ -106,7 +125,7 @@ export const PATH_DELIMITER = {
 
 **改善実施**:
 
-- `PLATFORM_TYPE.UNKNOWN`を空文字列に統一（全て文字列ベース）
+- `PLATFORM_TYPE.UNKNOWN`を空文字列に統一（すべて文字列ベース）
 - 型安全なプラットフォームマッピング
 - 詳細な型定義の提供
 
@@ -130,15 +149,15 @@ export const PATH_DELIMITER = {
 
 ### パフォーマンス
 
-- **初回実行**: `os.platform()`の1回呼び出し
-- **キャッシュ後**: 即座に返却
-- **メモリ使用量**: 最小限のキャッシュ変数のみ
+- 初回実行: `os.platform()`の 1回呼び出し
+- キャッシュ後: 即座に返却
+- メモリ使用量: 最小限のキャッシュ変数のみ
 
 ### 保守性
 
-- **コード品質**: ESLint/TSルール準拠
-- **型定義**: 完全な型情報提供
-- **構造化**: 責任分離されたファイル構成
+- コード品質: ESLint/TS ルール準拠
+- 型定義: 完全な型情報提供
+- 構造化: 責任分離されたファイル構成
 
 ## API仕様
 
@@ -204,9 +223,9 @@ const platform2 = estaUtils.getPlatform();
 
 ## 結論
 
-現在の実装は以下の改善を完了しています：
+現在の実装は以下の改善を完了しています。
 
-1. **型安全性**: 全て文字列ベースのenum、詳細な型定義
+1. **型安全性**: すべて文字列ベースの enum、詳細な型定義
 2. **パフォーマンス**: キャッシュ機構による最適化
 3. **保守性**: 責任分離された構造
 4. **拡張性**: 設定ベースのプラットフォーム定義

--- a/docs/specs/README.ja.md
+++ b/docs/specs/README.ja.md
@@ -1,0 +1,88 @@
+---
+header:
+  - src: docs/specs/@esta-core--tools-config.spec.md
+  - @(#) : ESTA Install Tools configuration reader
+title: /docs/specs/ 仕様書作成ガイドライン
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
+---
+
+## 📘 仕様書作成ガイドライン (日本語版)
+
+このドキュメントは、`docs/specs/*.spec.md` 形式で作成される **仕様書の統一運用ルール** を定めたものです。日本語で記述された仕様書向けに、構造や命名規則、記述スタイルを整理しています。
+
+### 📁 対象ディレクトリ
+
+```bash
+docs/specs/
+├── @esta-core-tools-config.spec.md
+├── @esta-core-cli.spec.md
+└── ...
+```
+
+### 🧩 ファイル命名規則
+
+- フォーマット：`<@スコープ>-<パッケージ名>.spec.md`
+  - 例：`@esta-core-tools-config.spec.md`
+- ``/`を Markdown安全な形式に置き換えるため、`--`で区切る
+
+---
+
+### 🧾 フロントマター (仕様書ヘッダ)
+
+すべての仕様書ファイルは、以下の YAML フロントマターを先頭に記述します。
+
+```yaml
+---
+header:
+  - src: docs/specs/@esta-core--tools-config.spec.md
+  - @(#) : ESTA Install Tools configuration reader
+title: 🔧 ツール設定統合管理仕様書（@esta-core/tools-config）
+version: 1.0.0
+created: 2025-07-14
+updated: 2025-07-14
+authors:
+  - 🤖 Claude（初期設計・API仕様策定）
+  - 👤 atsushifx（要件定義・仕様確定）
+changes:
+  - 2025-07-14: 初回作成（GitHub issue #94 対応）
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
+---
+```
+
+#### ✅ フィールド解説
+
+| フィールド    | 内容・目的                             |
+| ------------- | -------------------------------------- |
+| `header.src`  | 対象ファイルのパス。識別・検索用       |
+| `header.@(#)` | grep互換の識別コメント (CLI・UNIX向け) |
+| `title`       | 仕様書のタイトル。絵文字付きも可       |
+| `version`     | 文書のバージョン                       |
+| `created`     | 初版作成日                             |
+| `updated`     | 最終更新日                             |
+| `authors`     | 著者・AI含む役割付きリスト             |
+| `changes`     | 更新履歴 (日時と要約)                  |
+| `copyright`   | 著作権・ライセンス表記                 |
+
+#### 💡 補足ルール
+
+- `authors`は AI（例: Claude, GPT）も含めて記録可能
+- 絵文字や強調を適度に使い、可読性を意識
+- 検索性を考慮し、`@(#)`内にはユニークな識別子を含める
+
+### ✍️ 今後の拡張案
+
+- フロントマターに `tags:` フィールドを追加（機能分類や関連リンク）
+- Markdown から自動インデックス化（Docs ページ生成など）
+
+### 👤 運用責任者
+
+- メンテナ：`atsushifx`
+- 連絡先：[https://github.com/atsushifx](https://github.com/atsushifx)
+
+以上。すべての仕様書はこの規約に基づいて整備・管理されます。


### PR DESCRIPTION
## ✨ Overview

標準化された仕様書（`.spec.md`）をプロジェクト全体で整備・運用するためのルールとガイドラインを追加しました。

今回の変更では、以下2点を中心にドキュメント構造の統一を図っています：

- `README.ja.md` によるフロントマター・命名規則の明文化
- `@esta-core` / `@esta-utils` / `@esta-system` 向け命名ルールの統一（接頭語リネーム）

## 🔧 Changes

- [x] `docs/specs/README.ja.md` を新規作成（日本語ガイドライン）
- [x] 既存仕様ファイルを命名規則に従いリネーム
- [x] ドキュメント構造ルールを明文化
- [ ] その他のドキュメント整備対応に向けた基盤確立

## 📂 Related Issues

Related: None
Foundation work for multi-package specification consolidation

Branch: `docs/specs/restruct-rules`

## ✅ Checklist

- [ ] Lint checks pass (`pnpm lint`)
- [x] Documentation is updated
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

## 💬 Additional Notes

このガイドは `.spec.md` 形式の仕様書すべてに適用され、今後の開発・保守で統一的なドキュメント作成を支援します。

ご確認よろしくお願いします。
