### PR TITLE
feat: add ErrorResult and unify shared error types

### DIFF
--- a/configs/eslint.projects.js
+++ b/configs/eslint.projects.js
@@ -13,6 +13,8 @@ export default [
   // shared packages
   './shared/packages/constants/tsconfig.json',
   './shared/packages/types/tsconfig.json',
+  // esta-error
+  'packages/@esta-error/error-result/tsconfig.json',
   // esta-core
   'packages/@esta-core/feature-flags/tsconfig.json',
   'packages/@esta-core/error-handler/tsconfig.json',

--- a/docs/.cc-kiro/restructure-plan/phase01-1-error-handling.spec.md
+++ b/docs/.cc-kiro/restructure-plan/phase01-1-error-handling.spec.md
@@ -4,6 +4,8 @@ description: @esta-error/error-handler パッケージの詳細設計と統一�
 sidebar_position: 1.1
 ---
 
+> **Note**: このサブフェーズの実装では **t-wad式TDD（Test-Driven Development）** を採用します。テストファーストで実装を進め、品質と設計の確実性を保証します。
+
 # Phase 1.1: @esta-error/error-handler パッケージ仕様書
 
 ## 概要

--- a/docs/.cc-kiro/restructure-plan/phase01-2-runtime.spec.md
+++ b/docs/.cc-kiro/restructure-plan/phase01-2-runtime.spec.md
@@ -4,6 +4,8 @@ description: @esta-runtime パッケージの詳細設計と実装仕様（エ�
 sidebar_position: 1.2
 ---
 
+> **Note**: このサブフェーズの実装では **t-wad式TDD（Test-Driven Development）** を採用します。テストファーストで実装を進め、品質と設計の確実性を保証します。
+
 # Phase 1.2: @esta-runtime パッケージ仕様書
 
 ## 概要

--- a/docs/.cc-kiro/restructure-plan/phase01-foundation.md
+++ b/docs/.cc-kiro/restructure-plan/phase01-foundation.md
@@ -6,6 +6,8 @@ sidebar_position: 1
 
 # Phase 1: Foundation Packages
 
+> **Note**: このフェーズの実装では **t-wad式TDD（Test-Driven Development）** を採用します。テストファーストで実装を進め、品質と設計の確実性を保証します。
+
 # Phase 1: 基盤パッケージ作成
 
 ## 実行コマンド

--- a/docs/.cc-kiro/restructure-plan/phase02-integration.md
+++ b/docs/.cc-kiro/restructure-plan/phase02-integration.md
@@ -6,6 +6,8 @@ sidebar_position: 2
 
 # Phase 2: Integration Packages
 
+> **Note**: このフェーズの実装では **t-wad式TDD（Test-Driven Development）** を採用します。テストファーストで実装を進め、品質と設計の確実性を保証します。
+
 # Phase 2: 機能統合パッケージ作成
 
 ## 実行コマンド

--- a/docs/.cc-kiro/restructure-plan/phase03-application-integration.md
+++ b/docs/.cc-kiro/restructure-plan/phase03-application-integration.md
@@ -4,6 +4,8 @@ description: アプリケーションレイヤーの統合とGitHub Actions機�
 sidebar_position: 3
 ---
 
+> **Note**: このフェーズの実装では **t-wad式TDD（Test-Driven Development）** を採用します。テストファーストで実装を進め、品質と設計の確実性を保証します。
+
 # Phase 3: アクション・システムパッケージ整理 - 詳細設計書
 
 **Version**: 1.0\

--- a/docs/.cc-kiro/restructure-plan/phase04-system-actions.md
+++ b/docs/.cc-kiro/restructure-plan/phase04-system-actions.md
@@ -4,6 +4,8 @@ description: エンドユーザー向け統合パッケージと包括的テス�
 sidebar_position: 4
 ---
 
+> **Note**: このフェーズの実装では **t-wad式TDD（Test-Driven Development）** を採用します。テストファーストで実装を進め、品質と設計の確実性を保証します。
+
 # Phase 4: 統合レイヤー作成とテスト強化 - 詳細設計書
 
 **Version**: 1.0\

--- a/docs/.cc-kiro/restructure-plan/phase05-unified-packages.md
+++ b/docs/.cc-kiro/restructure-plan/phase05-unified-packages.md
@@ -4,6 +4,8 @@ description: パフォーマンス最適化と包括的ドキュメント整備�
 sidebar_position: 5
 ---
 
+> **Note**: このフェーズの実装では **t-wad式TDD（Test-Driven Development）** を採用します。テストファーストで実装を進め、品質と設計の確実性を保証します。
+
 # Phase 5: 最適化・ドキュメント整備・クリーンアップ - 詳細設計書
 
 **Version**: 1.0\

--- a/packages/@esta-core/error-handler/src/fatalExit.ts
+++ b/packages/@esta-core/error-handler/src/fatalExit.ts
@@ -8,8 +8,6 @@
 
 // libs
 import { getLogger } from '@agla-utils/ag-logger';
-// constants
-import { ExitCode } from '@shared/constants';
 // types
 import type { TExitCode } from '@shared/constants';
 // classes
@@ -20,13 +18,13 @@ import { formatErrorMessage } from './utils/exitCodeUtils';
 /**
  * 致命的エラーでアプリケーションを終了
  * エラーをログに記録して致命的ExitErrorをスロー
+ * @param code 終了コード
  * @param message エラーメッセージ
- * @param code 終了コード（デフォルト: ExitCode.EXEC_FAILURE）
  * @throws ExitError 常に致命的ExitErrorをスロー
  */
 export const fatalExit = (
+  code: TExitCode,
   message: string,
-  code: TExitCode = ExitCode.EXEC_FAILURE,
 ): never => {
   const logger = getLogger();
   const formattedMessage = formatErrorMessage('FATAL', code, message);

--- a/packages/@esta-error/error-handler/.gitignore
+++ b/packages/@esta-error/error-handler/.gitignore
@@ -1,0 +1,83 @@
+# src: .gitignore
+#
+## @(#) : gitignore for monorepo sub repository
+#
+# @version  1.0.0
+# @author   Furukawa, Atsushi <atsushifx@aglabo.com>
+# @since    2025-04-11
+# @license	MIT
+#
+# @description<<
+#
+# Git ignore rules for textlint plugin development.
+# Includes common Node.js patterns and workspace-specific overrides.
+#
+#<<
+
+## ─── General (logs, patches) ───────────────────────────────
+*.log*
+*.diff
+*.patch
+
+## ─── Editor (VSCode) ──────────────────────────────────────
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+!.vscode/cspell*
+
+.history/
+
+## ─── Node.js / JS project ignores ─────────────────────────
+# gibo: Node.gitignore
+logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Diagnostic reports
+report.*.json
+
+# Runtime files
+pids
+*.pid
+*.seed
+*.pid.lock
+
+## ─── TypeScript artifacts ────────────────────────────────
+*.tsbuildinfo
+
+## ─── Build outputs ───────────────────────────────────────
+dist/
+lib/
+module/
+
+
+## ─── Cache
+.cache/
+.rpt2_cache/
+.rts2_cache_*/
+.parcel-cache
+.vitest
+
+## --- temp
+temp/*
+tmp/*
+
+## ─── Lint and test caches ────────────────────────────────
+*cache
+.eslintcache
+.stylelintcache
+
+## ─── Others ───────────────────────────────────────────
+node_modules/
+*.tgz
+
+.env
+.env.*.local
+.tools
+

--- a/packages/@esta-error/error-handler/.vscode/cspell.json
+++ b/packages/@esta-error/error-handler/.vscode/cspell.json
@@ -1,0 +1,24 @@
+// @(#) : cspell settings for this workspace
+/**
+ *
+ * @version  1.0.0
+ * @author   Furukawa, Atsushi <https://github.com/atsushifx>
+ * @since    2025-02-27
+ * @license  MIT
+ *
+ * @description<<
+ *
+ * this file is cspell (Code Spell Checker) settings for this workspace.
+ *
+ *<<
+ */
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/packages/cspell-types/cspell.schema.json",
+  "version": "0.2",
+  "import": [
+    "${env:XDG_CONFIG_HOME}/vscode/cspell.config.json",
+    "../../../../.vscode/cspell.json"
+  ],
+  "language": "en",
+  "caseSensitive": true
+}

--- a/packages/@esta-error/error-handler/configs/commitlint.config.ts
+++ b/packages/@esta-error/error-handler/configs/commitlint.config.ts
@@ -1,0 +1,24 @@
+// src: commitlint.config.ts
+// @(#) : commitlint configuration for this workspace
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// import commitlint config type
+import type { UserConfig } from '@commitlint/types';
+
+// import base Config
+import { default as baseConfig } from '../../../../base/configs/commitlint.config.base';
+
+const config: UserConfig = {
+  ...baseConfig,
+  rules: {
+    ...baseConfig.rules,
+    // write rules if necessary
+    // 'header-max-length': [2, 'always', 72], etc
+  },
+};
+
+export default config;

--- a/packages/@esta-error/error-handler/configs/eslint.config.js
+++ b/packages/@esta-error/error-handler/configs/eslint.config.js
@@ -1,0 +1,33 @@
+// src: configs/eslint.config.js
+// @(#) : ESLint flat config for TypeScript workspace
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs
+
+// import form common base config
+import baseConfig from '../../../../base/configs/eslint.config.base.js';
+
+// settings
+export default [
+  ...baseConfig,
+
+  // source code settings
+  {
+    files: [
+      'src/**/*.ts',
+      'shared/**/*.ts',
+      'tests/**/*.ts',
+    ],
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
+  },
+];

--- a/packages/@esta-error/error-handler/configs/eslint.config.typed.js
+++ b/packages/@esta-error/error-handler/configs/eslint.config.typed.js
@@ -1,0 +1,41 @@
+// src: configs/eslint.config.typed.js
+// @(#) : eslint float config for type check
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// parser
+import tsparser from '@typescript-eslint/parser';
+
+// import form common base config
+import baseConfig from '../../../../base/configs/eslint.config.typed.base.js';
+
+export default [
+  ...baseConfig,
+  // --- source code
+  // source codes settings
+  {
+    files: [
+      'src/**/*.ts',
+      'shared/**/*.ts',
+      'tests/**/*.ts',
+    ],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: '.',
+        sourceType: 'module',
+      },
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
+  },
+];

--- a/packages/@esta-error/error-handler/configs/secretlint.config.yaml
+++ b/packages/@esta-error/error-handler/configs/secretlint.config.yaml
@@ -1,0 +1,10 @@
+# src: shared/configs/secretlint.config.base.yaml
+# @(#) : secretlint base configuration
+#
+# Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+rules:
+  - id: "@secretlint/secretlint-rule-preset-recommend"

--- a/packages/@esta-error/error-handler/configs/tsup.config.module.ts
+++ b/packages/@esta-error/error-handler/configs/tsup.config.module.ts
@@ -1,0 +1,24 @@
+// src: configs/tsup.config.module.ts
+// @(#) : tsup config for esm module
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// system config
+import { defineConfig } from 'tsup';
+
+// user config
+import { baseConfig } from '../../../../base/configs/tsup.config.base';
+
+// configs
+export default defineConfig({
+  ...baseConfig,
+
+  // sub-packages definition
+  format: ['esm'],
+  outDir: 'module', // for ESM
+  // tsconfig
+  tsconfig: './tsconfig.json',
+});

--- a/packages/@esta-error/error-handler/configs/tsup.config.ts
+++ b/packages/@esta-error/error-handler/configs/tsup.config.ts
@@ -1,0 +1,23 @@
+// src: configs/tsup.config.ts
+// @(#) : tsup config for CommonJS module
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// system config
+import { defineConfig } from 'tsup';
+
+// user config
+import { baseConfig } from '../../../../base/configs/tsup.config.base';
+
+export default defineConfig({
+  ...baseConfig,
+
+  // sub packages definition
+  format: ['cjs'],
+  outDir: 'lib', // for CJS
+  // tsconfig
+  tsconfig: './tsconfig.json',
+});

--- a/packages/@esta-error/error-handler/configs/vitest.config.e2e.ts
+++ b/packages/@esta-error/error-handler/configs/vitest.config.e2e.ts
@@ -1,0 +1,39 @@
+// src: shared/common/configs/vitest.config.e2e.ts
+// @(#) : vitest config for end-to-end test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs for base directory
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// system config
+import { mergeConfig } from 'vitest/config';
+
+// shared base config
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // CI (End-to-End) Tests
+      'tests/e2e/**/*.test.ts',
+      'tests/e2e/**/*.spec.ts',
+    ],
+    caches: {
+      dir: path.resolve(__dirname, '../../../.cache/vitest-cache/e2e/'),
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../src'),
+    },
+  },
+});

--- a/packages/@esta-error/error-handler/configs/vitest.config.integration.ts
+++ b/packages/@esta-error/error-handler/configs/vitest.config.integration.ts
@@ -1,0 +1,38 @@
+// src: shared/common/configs/vitest.config.integration.ts
+// @(#) : vitest config for integration test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs for base directory
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// system config
+import { mergeConfig } from 'vitest/config';
+
+// shared base config
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // CI (Integration) Tests
+      'tests/integration/**/*.test.ts',
+      'tests/integration/**/*.spec.ts',
+    ],
+    caches: {
+      dir: path.resolve(__dirname, '../../../.cache/vitest-cache/integration/'),
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../src'),
+    },
+  },
+});

--- a/packages/@esta-error/error-handler/configs/vitest.config.unit.ts
+++ b/packages/@esta-error/error-handler/configs/vitest.config.unit.ts
@@ -1,0 +1,38 @@
+// src: shared/common/configs/vitest.config.unit.ts
+// @(#) : vitest config for unit test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs for base directory
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// system config
+import { mergeConfig } from 'vitest/config';
+
+// shared base config
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // Unit Test (develop test) exec only sub repositories
+      'src/**/*.test.ts',
+      'src/**/*.spec.ts',
+    ],
+    caches: {
+      dir: path.resolve(__dirname, '../../../.cache/vitest-cache/unit/'),
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../src'),
+    },
+  },
+});

--- a/packages/@esta-error/error-handler/package.json
+++ b/packages/@esta-error/error-handler/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@esta-error/error-handler",
+  "_comment": "@(#) @esta-error: ESTA Error Handler",
+  "private": true,
+  "version": "0.0.0",
+  "description": "統一エラーハンドリングとプロセス終了管理を提供するパッケージ",
+  "author": "atsushifx <https://github.com/atsushifx>",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./lib/index.js",
+  "module": "./module/index.js",
+  "types": "./module/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./module/index.d.ts",
+      "import": "./module/index.js",
+      "require": "./lib/index.cjs"
+    }
+  },
+  "files": [
+    "lib",
+    "module"
+  ],
+  "scripts": {
+    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build:cjs": "tsup --config ./configs/tsup.config.ts",
+    "build:esm": "tsup --config ./configs/tsup.config.module.ts",
+    "clean": "rimraf lib module .cache",
+    "format:dprint": "dprint fmt",
+    "check:dprint": "dprint check",
+    "check:types": "tsc --noEmit --incremental",
+    "check:spells": "cspell --config .vscode/cspell.json --cache --cache-location ../../../.cache/cspell/cSpellCache",
+    "lint": "pnpm exec eslint --config ./configs/eslint.config.js --cache --cache-location ../../../.cache/eslint-cache/esLintCache ",
+    "lint:types": "pnpm exec eslint --config ./configs/eslint.config.typed.js --cache --cache-location ../../../.cache/eslint-cache/esLintCache",
+    "lint:all": "pnpm run lint && pnpm run lint:types",
+    "lint:fix": "pnpm run lint --fix",
+    "lint:secrets": "secretlint --secretlintrc ./configs/secretlint.config.yaml --secretlintignore .gitignore --maskSecrets **/*",
+    "test:all": "pnpm run test:develop && pnpm run test:ci && pnpm run test:e2e",
+    "test:develop": "pnpm exec vitest run --config ./configs/vitest.config.unit.ts",
+    "test:ci": "pnpm exec vitest run --config ./configs/vitest.config.integration.ts",
+    "test:e2e": "pnpm exec vitest run --config ./configs/vitest.config.e2e.ts",
+    "sync:configs": "bash ../../../scripts/sync-configs.sh . "
+  },
+  "engines": {
+    "pnpm": ">=10",
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@agla-utils/ag-logger": "workspace:*",
+    "@shared/constants": "workspace:*"
+  },
+  "devDependencies": {}
+}

--- a/packages/@esta-error/error-handler/src/__tests__/errorExit.spec.ts
+++ b/packages/@esta-error/error-handler/src/__tests__/errorExit.spec.ts
@@ -1,0 +1,33 @@
+// src: ./__tests__/errorExit.spec.ts
+// @(#): errorExit関数のユニットテスト
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// constants
+import { ExitCode } from '@shared/constants';
+// test framework
+import { describe, expect, it } from 'vitest';
+// classes
+import { ExitError } from '../error/ExitError';
+// test target
+import { errorExit } from '../errorExit';
+
+describe('errorExit', () => {
+  it('should throw ExitError with fatal=false', () => {
+    expect(() => {
+      errorExit(ExitCode.INVALID_ARGS, 'invalid arguments');
+    }).toThrow(ExitError);
+
+    try {
+      errorExit(ExitCode.INVALID_ARGS, 'invalid arguments');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExitError);
+      expect((error as ExitError).isFatal()).toBe(false);
+      expect((error as ExitError).code).toBe(ExitCode.INVALID_ARGS);
+      expect((error as ExitError).message).toBe('invalid arguments');
+    }
+  });
+});

--- a/packages/@esta-error/error-handler/src/__tests__/fatalExit.spec.ts
+++ b/packages/@esta-error/error-handler/src/__tests__/fatalExit.spec.ts
@@ -1,0 +1,44 @@
+// src: ./__tests__/fatalExit.spec.ts
+// @(#): fatalExit関数のユニットテスト
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// constants
+import { ExitCode } from '@shared/constants';
+// test framework
+import { describe, expect, it } from 'vitest';
+// classes
+import { ExitError } from '../error/ExitError';
+// test target
+import { fatalExit } from '../fatalExit';
+
+describe('fatalExit', () => {
+  it('should throw ExitError with fatal=true and default code', () => {
+    expect(() => {
+      fatalExit(ExitCode.EXEC_FAILURE, 'test fatal error');
+    }).toThrow(ExitError);
+
+    try {
+      fatalExit(ExitCode.EXEC_FAILURE, 'test fatal error');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExitError);
+      expect((error as ExitError).isFatal()).toBe(true);
+      expect((error as ExitError).code).toBe(ExitCode.EXEC_FAILURE);
+      expect((error as ExitError).message).toBe('test fatal error');
+    }
+  });
+
+  it('should throw ExitError with fatal=true and custom code', () => {
+    try {
+      fatalExit(ExitCode.CONFIG_ERROR, 'config not found');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ExitError);
+      expect((error as ExitError).isFatal()).toBe(true);
+      expect((error as ExitError).code).toBe(ExitCode.CONFIG_ERROR);
+      expect((error as ExitError).message).toBe('config not found');
+    }
+  });
+});

--- a/packages/@esta-error/error-handler/src/__tests__/handleExitError.spec.ts
+++ b/packages/@esta-error/error-handler/src/__tests__/handleExitError.spec.ts
@@ -1,0 +1,103 @@
+// src: ./__tests__/handleExitError.spec.ts
+// @(#): handleExitError関数のユニットテスト
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// constants
+import { ExitCode } from '@shared/constants';
+// test framework
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// modules
+import { initEstaFeatures, TEstaExecutionMode } from '@esta-core/feature-flags';
+// classes
+import { ExitError } from '../error/ExitError';
+
+// Mock @actions/core
+vi.mock('@actions/core', () => ({
+  setFailed: vi.fn(),
+}));
+
+// test target
+import { handleExitError } from '../handleExitError';
+
+describe('handleExitError', () => {
+  const mockProcessExit = vi.fn() as unknown as (code?: string | number | null | undefined) => never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('GitHub Actions environment', () => {
+    beforeEach(() => {
+      // Set GitHub Actions execution mode
+      initEstaFeatures(TEstaExecutionMode.GITHUB_ACTIONS);
+    });
+
+    it('should call core.setFailed for non-fatal error', async () => {
+      const error = new ExitError(ExitCode.INVALID_ARGS, 'Test error message', false);
+      const core = await import('@actions/core');
+
+      handleExitError(error);
+
+      expect(core.setFailed).toHaveBeenCalledWith('[ERROR 13] Test error message');
+    });
+
+    it('should call core.setFailed for fatal error', async () => {
+      const error = new ExitError(ExitCode.EXEC_FAILURE, 'Fatal error', true);
+      const core = await import('@actions/core');
+
+      handleExitError(error);
+
+      expect(core.setFailed).toHaveBeenCalledWith('[FATAL 1] Fatal error');
+    });
+  });
+
+  describe('CLI environment', () => {
+    beforeEach(() => {
+      // Set CLI execution mode
+      initEstaFeatures(TEstaExecutionMode.CLI);
+
+      // Mock process.exit
+      vi.spyOn(process, 'exit').mockImplementation(mockProcessExit);
+    });
+
+    it('should call process.exit for non-fatal error', () => {
+      const error = new ExitError(ExitCode.INVALID_ARGS, 'CLI error message', false);
+
+      handleExitError(error);
+
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.INVALID_ARGS);
+    });
+
+    it('should call process.exit for fatal error', () => {
+      const error = new ExitError(ExitCode.EXEC_FAILURE, 'Fatal CLI error', true);
+
+      handleExitError(error);
+
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.EXEC_FAILURE);
+    });
+
+    it('should call process.exit with correct code for SUCCESS', () => {
+      const error = new ExitError(ExitCode.SUCCESS, 'Success message', false);
+
+      handleExitError(error);
+
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.SUCCESS);
+    });
+
+    it('should call process.exit with correct code for UNKNOWN_ERROR', () => {
+      const error = new ExitError(ExitCode.UNKNOWN_ERROR, 'Unknown error', true);
+
+      handleExitError(error);
+
+      expect(mockProcessExit).toHaveBeenCalledWith(ExitCode.UNKNOWN_ERROR);
+    });
+  });
+});

--- a/packages/@esta-error/error-handler/src/error/ExitError.ts
+++ b/packages/@esta-error/error-handler/src/error/ExitError.ts
@@ -1,0 +1,44 @@
+// src: ./error/ExitError.ts
+// @(#): 終了エラークラス実装
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// types
+import type { TExitCode } from '@shared/constants';
+
+/**
+ * 終了コードと致命的フラグを持つカスタムエラークラス
+ * アプリケーションの終了時に使用される統一されたエラー処理を提供
+ */
+export class ExitError extends Error {
+  readonly code: TExitCode;
+  readonly fatal: boolean;
+
+  /**
+   * ExitErrorインスタンスを作成
+   * @param code 終了コード
+   * @param message エラーメッセージ
+   * @param fatal 致命的エラーかどうか（デフォルト: false）
+   */
+  constructor(code: TExitCode, message: string, fatal = false) {
+    super(message);
+    this.name = 'ExitError';
+    this.code = code;
+    this.fatal = fatal;
+    Object.setPrototypeOf(this, new.target.prototype);
+
+    // NOTE: Claude Code should not modify this line - optional chaining is intentional for Node.js compatibility
+    Error.captureStackTrace?.(this, ExitError);
+  }
+
+  /**
+   * エラーが致命的かどうかを判定
+   * @returns 致命的エラーの場合true
+   */
+  isFatal(): boolean {
+    return this.fatal;
+  }
+}

--- a/packages/@esta-error/error-handler/src/error/__tests__/ExitError.spec.ts
+++ b/packages/@esta-error/error-handler/src/error/__tests__/ExitError.spec.ts
@@ -1,0 +1,36 @@
+// src: ./error/__tests__/ExitError.spec.ts
+// @(#): ExitErrorクラスのユニットテスト
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// constants
+import { ExitCode } from '@shared/constants';
+// test framework
+import { describe, expect, it } from 'vitest';
+// test target
+import { ExitError } from '../ExitError';
+
+describe('ExitError', () => {
+  it('should extend Error class', () => {
+    const error = new ExitError(ExitCode.EXEC_FAILURE, 'test message');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('should have code property with correct value', () => {
+    const error = new ExitError(ExitCode.CONFIG_ERROR, 'test message');
+    expect(error.code).toBe(ExitCode.CONFIG_ERROR);
+  });
+
+  it('should have isFatal method that returns false by default', () => {
+    const error = new ExitError(ExitCode.EXEC_FAILURE, 'test message');
+    expect(error.isFatal()).toBe(false);
+  });
+
+  it('should have isFatal method that returns true when fatal=true', () => {
+    const error = new ExitError(ExitCode.EXEC_FAILURE, 'test message', true);
+    expect(error.isFatal()).toBe(true);
+  });
+});

--- a/packages/@esta-error/error-handler/src/errorExit.ts
+++ b/packages/@esta-error/error-handler/src/errorExit.ts
@@ -1,0 +1,33 @@
+// src: ./errorExit.ts
+// @(#): 非致命的エラー終了関数
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs
+import { getLogger } from '@agla-utils/ag-logger';
+// types
+import type { TExitCode } from '@shared/constants';
+// classes
+import { ExitError } from './error/ExitError';
+// utils
+import { formatErrorMessage } from './utils/exitCodeUtils';
+
+/**
+ * 非致命的エラーでアプリケーションを終了
+ * エラーをログに記録してExitErrorをスロー
+ * @param code 終了コード
+ * @param message エラーメッセージ
+ * @throws ExitError 常にExitErrorをスロー
+ */
+export const errorExit = (
+  code: TExitCode,
+  message: string,
+): never => {
+  const logger = getLogger();
+  const formattedMessage = formatErrorMessage('ERROR', code, message);
+  logger.error(formattedMessage);
+  throw new ExitError(code, message);
+};

--- a/packages/@esta-error/error-handler/src/fatalExit.ts
+++ b/packages/@esta-error/error-handler/src/fatalExit.ts
@@ -1,0 +1,33 @@
+// src: ./fatalExit.ts
+// @(#): 致命的エラー終了関数
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs
+import { getLogger } from '@agla-utils/ag-logger';
+// types
+import type { TExitCode } from '@shared/constants';
+// classes
+import { ExitError } from './error/ExitError';
+// utils
+import { formatErrorMessage } from './utils/exitCodeUtils';
+
+/**
+ * 致命的エラーでアプリケーションを終了
+ * エラーをログに記録して致命的ExitErrorをスロー
+ * @param code 終了コード
+ * @param message エラーメッセージ
+ * @throws ExitError 常に致命的ExitErrorをスロー
+ */
+export const fatalExit = (
+  code: TExitCode,
+  message: string,
+): never => {
+  const logger = getLogger();
+  const formattedMessage = formatErrorMessage('FATAL', code, message);
+  logger.fatal(formattedMessage);
+  throw new ExitError(code, message, true);
+};

--- a/packages/@esta-error/error-handler/src/handleExitError.ts
+++ b/packages/@esta-error/error-handler/src/handleExitError.ts
@@ -1,0 +1,30 @@
+// src: ./handleExitError.ts
+// @(#): ExitErrorハンドラ関数
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs
+import * as core from '@actions/core';
+// modules
+import { estaFeatures, TEstaExecutionMode } from '@esta-core/feature-flags';
+// types
+import type { ExitError } from './error/ExitError';
+
+/**
+ * ExitErrorを処理して適切な方法でアプリケーションを終了
+ * GitHub Actions環境ではcore.setFailedを使用、それ以外ではprocess.exitを使用
+ * @param err 処理するExitErrorインスタンス
+ */
+export const handleExitError = (err: ExitError): void => {
+  const prefix = err.isFatal() ? 'FATAL' : 'ERROR';
+  const message = `[${prefix} ${err.code}] ${err.message}`;
+
+  if (estaFeatures.executionMode === TEstaExecutionMode.GITHUB_ACTIONS) {
+    core.setFailed(message);
+  } else {
+    process.exit(err.code);
+  }
+};

--- a/packages/@esta-error/error-handler/src/index.ts
+++ b/packages/@esta-error/error-handler/src/index.ts
@@ -1,0 +1,18 @@
+// src: ./index.ts
+// @(#): エラーハンドラパッケージのエントリポイント
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// constants
+export { ExitCode } from '@shared/constants';
+// types
+export type { TExitCode } from '@shared/constants';
+// classes
+export { ExitError } from './error/ExitError';
+// functions
+export { errorExit } from './errorExit';
+export { fatalExit } from './fatalExit';
+export { handleExitError } from './handleExitError';

--- a/packages/@esta-error/error-handler/src/utils/exitCodeUtils.ts
+++ b/packages/@esta-error/error-handler/src/utils/exitCodeUtils.ts
@@ -1,0 +1,61 @@
+// src: ./utils/exitCodeUtils.ts
+// @(#): 終了コード関連のユーティリティ関数
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// types
+import type { TExitCode } from '@shared/constants';
+// constants
+import { ExitCode, ExitCodeErrorMessage } from '@shared/constants';
+
+/**
+ * 終了コードに対応するエラーメッセージを取得
+ * @param code 終了コード
+ * @returns エラーメッセージ
+ */
+export const getExitCodeMessage = (code: TExitCode): string => {
+  // NOTE: Claude Code should not modify this line - fallback is intentional for type safety
+  return ExitCodeErrorMessage[code] ?? ExitCodeErrorMessage[ExitCode.UNKNOWN_ERROR];
+};
+
+/**
+ * 呼び出し元の情報を取得
+ * @returns 呼び出し元のファイル名または関数名
+ */
+const getCaller = (): string => {
+  const stack = new Error().stack;
+  if (!stack) { return 'unknown'; }
+
+  const lines = stack.split('\n');
+  // スタックトレースを解析して、errorExit/fatalExitを呼び出した実際のアプリケーション関数を探す
+  // スタック: getCaller -> formatErrorMessage -> errorExit/fatalExit -> 実際の呼び出し元
+  const callerLine = lines[5]; // より上位の呼び出し元を取得
+  if (!callerLine) { return 'unknown'; }
+
+  // ファイル名を抽出 (例: at functionName (C:\path\to\file.ts:line:column))
+  const match = callerLine.match(/at\s+(?:(.+?)\s+\()?.*[/\\]([^/\\]+):\d+:\d+/);
+  if (match) {
+    const functionName = match[1];
+    const fileName = match[2];
+    // 関数名がある場合は優先、なければファイル名を使用
+    return functionName || fileName.replace(/\.(ts|js)$/, '');
+  }
+
+  return 'unknown';
+};
+
+/**
+ * 統一されたエラーメッセージフォーマットを作成
+ * @param logLevel ログレベル（ERROR/FATAL）
+ * @param code 終了コード
+ * @param userMessage ユーザー指定のメッセージ
+ * @returns フォーマットされたエラーメッセージ
+ */
+export const formatErrorMessage = (logLevel: 'ERROR' | 'FATAL', code: TExitCode, userMessage: string): string => {
+  const caller = getCaller();
+  const systemMessage = getExitCodeMessage(code);
+  return `[${logLevel}(${code})] ${systemMessage}: ${userMessage} in ${caller}`;
+};

--- a/packages/@esta-error/error-handler/tests/e2e/errorExit.spec.ts
+++ b/packages/@esta-error/error-handler/tests/e2e/errorExit.spec.ts
@@ -1,0 +1,135 @@
+import { AgLogLevelCode, E2eMockLogger, getLogger, PlainFormat } from '@agla-utils/ag-logger';
+import { ExitCode } from '@shared/constants';
+import type { TExitCode } from '@shared/constants';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ExitError } from '../../src/error/ExitError';
+import { errorExit } from '../../src/errorExit';
+
+describe('errorExit E2E Tests', () => {
+  let mockLogger: E2eMockLogger;
+
+  beforeEach(() => {
+    mockLogger = new E2eMockLogger();
+    const logger = getLogger();
+    logger.setLogLevel(AgLogLevelCode.ERROR);
+    logger.setLogger({
+      defaultLogger: mockLogger.error.bind(mockLogger),
+      formatter: PlainFormat,
+      loggerMap: {
+        [AgLogLevelCode.FATAL]: mockLogger.fatal.bind(mockLogger),
+        [AgLogLevelCode.ERROR]: mockLogger.error.bind(mockLogger),
+        [AgLogLevelCode.WARN]: mockLogger.warn.bind(mockLogger),
+        [AgLogLevelCode.INFO]: mockLogger.info.bind(mockLogger),
+        [AgLogLevelCode.DEBUG]: mockLogger.debug.bind(mockLogger),
+        [AgLogLevelCode.TRACE]: mockLogger.trace.bind(mockLogger),
+      },
+    });
+  });
+
+  describe('エラーログ出力とExitError例外の統合テスト', () => {
+    it('正常なエラーコードでエラーログを出力し、ExitErrorを投げる', () => {
+      const testCode = ExitCode.INVALID_ARGS;
+      const testMessage = 'Invalid argument provided';
+
+      expect(() => errorExit(testCode, testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.ERROR);
+      expect(logMessage).toContain('[ERROR(13)] Invalid command line arguments: Invalid argument provided in');
+      // 実際の呼び出し元の関数名またはファイル名が含まれることを確認
+      expect(logMessage).toMatch(/in \w+/);
+
+      try {
+        errorExit(testCode, testMessage);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ExitError);
+        expect((error as ExitError).code).toBe(testCode);
+        expect((error as ExitError).message).toBe(testMessage);
+        expect((error as ExitError).isFatal()).toBe(false);
+      }
+    });
+
+    it('未定義のエラーコードでもエラーログを出力し、ExitErrorを投げる', () => {
+      const testCode = 999 as TExitCode;
+      const testMessage = 'Unknown error scenario';
+
+      expect(() => errorExit(testCode, testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.ERROR);
+      expect(logMessage).toContain('[ERROR(999)] Unknown error: Unknown error scenario in');
+      expect(logMessage).toMatch(/in \w+/);
+
+      try {
+        errorExit(testCode, testMessage);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ExitError);
+        expect((error as ExitError).code).toBe(testCode);
+        expect((error as ExitError).message).toBe(testMessage);
+        expect((error as ExitError).isFatal()).toBe(false);
+      }
+    });
+
+    it('複数回呼び出しでも正常に動作する', () => {
+      const testCases = [
+        { code: ExitCode.INVALID_ARGS, message: 'First error' },
+        { code: ExitCode.EXEC_FAILURE, message: 'Second error' },
+        { code: ExitCode.FILE_IO_ERROR, message: 'Third error' },
+      ];
+
+      testCases.forEach(({ code, message }) => {
+        expect(() => errorExit(code, message)).toThrow(ExitError);
+      });
+
+      const errorMessages = mockLogger.getMessages(AgLogLevelCode.ERROR);
+      expect(errorMessages).toHaveLength(3);
+      expect(errorMessages[0]).toContain('[ERROR(13)] Invalid command line arguments: First error in');
+      expect(errorMessages[1]).toContain('[ERROR(1)] General execution failure: Second error in');
+      expect(errorMessages[2]).toContain('[ERROR(15)] File I/O operation failed: Third error in');
+    });
+
+    it('空のメッセージでも正常に動作する', () => {
+      const testCode = ExitCode.INVALID_ARGS;
+      const testMessage = '';
+
+      expect(() => errorExit(testCode, testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.ERROR);
+      expect(logMessage).toContain('[ERROR(13)] Invalid command line arguments:');
+      expect(logMessage).toMatch(/in \w+/);
+    });
+
+    it('長いメッセージでも正常に動作する', () => {
+      const testCode = ExitCode.EXEC_FAILURE;
+      const testMessage = 'A'.repeat(1000);
+
+      expect(() => errorExit(testCode, testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.ERROR);
+      expect(logMessage).toContain(`[ERROR(1)] General execution failure: ${testMessage} in`);
+      expect(logMessage).toMatch(/in \w+/);
+    });
+  });
+
+  describe('agLoggerとの統合テスト', () => {
+    it('getLoggerが正しく呼び出される', () => {
+      const testCode = ExitCode.INVALID_ARGS;
+      const testMessage = 'Test message';
+
+      expect(() => errorExit(testCode, testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.ERROR);
+      expect(logMessage).toContain('[ERROR(13)] Invalid command line arguments: Test message in');
+      expect(logMessage).toMatch(/in \w+/);
+    });
+
+    it('logger.errorが正しいフォーマットで呼び出される', () => {
+      const testCode = ExitCode.FILE_IO_ERROR;
+      const testMessage = 'config.json not found';
+
+      expect(() => errorExit(testCode, testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.ERROR);
+      expect(logMessage).toContain('[ERROR(15)] File I/O operation failed: config.json not found in');
+      expect(logMessage).toMatch(/in \w+/);
+    });
+  });
+});

--- a/packages/@esta-error/error-handler/tests/e2e/fatalExit.spec.ts
+++ b/packages/@esta-error/error-handler/tests/e2e/fatalExit.spec.ts
@@ -1,0 +1,172 @@
+import { AgLogLevelCode, E2eMockLogger, getLogger, PlainFormat } from '@agla-utils/ag-logger';
+import { ExitCode } from '@shared/constants';
+import type { TExitCode } from '@shared/constants';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ExitError } from '../../src/error/ExitError';
+import { fatalExit } from '../../src/fatalExit';
+
+describe('fatalExit E2E Tests', () => {
+  let mockLogger: E2eMockLogger;
+
+  beforeEach(() => {
+    mockLogger = new E2eMockLogger();
+    const logger = getLogger();
+    logger.setLogLevel(AgLogLevelCode.FATAL);
+    logger.setLogger({
+      defaultLogger: mockLogger.fatal.bind(mockLogger),
+      formatter: PlainFormat,
+      loggerMap: {
+        [AgLogLevelCode.FATAL]: mockLogger.fatal.bind(mockLogger),
+        [AgLogLevelCode.ERROR]: mockLogger.error.bind(mockLogger),
+        [AgLogLevelCode.WARN]: mockLogger.warn.bind(mockLogger),
+        [AgLogLevelCode.INFO]: mockLogger.info.bind(mockLogger),
+        [AgLogLevelCode.DEBUG]: mockLogger.debug.bind(mockLogger),
+        [AgLogLevelCode.TRACE]: mockLogger.trace.bind(mockLogger),
+      },
+    });
+  });
+
+  describe('致命的エラーログ出力とExitError例外の統合テスト', () => {
+    it('デフォルトのエラーコードで致命的エラーログを出力し、ExitErrorを投げる', () => {
+      const testMessage = 'Critical system failure';
+
+      expect(() => fatalExit(testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.FATAL);
+      expect(logMessage).toContain('[FATAL(1)] General execution failure: Critical system failure in');
+      expect(logMessage).toMatch(/in \w+/);
+
+      try {
+        fatalExit(testMessage);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ExitError);
+        expect((error as ExitError).code).toBe(ExitCode.EXEC_FAILURE);
+        expect((error as ExitError).message).toBe(testMessage);
+        expect((error as ExitError).isFatal()).toBe(true);
+      }
+    });
+
+    it('指定されたエラーコードで致命的エラーログを出力し、ExitErrorを投げる', () => {
+      const testCode = ExitCode.INVALID_ARGS;
+      const testMessage = 'Invalid configuration file';
+
+      expect(() => fatalExit(testMessage, testCode)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.FATAL);
+      expect(logMessage).toContain('[FATAL(13)] Invalid command line arguments: Invalid configuration file in');
+      expect(logMessage).toMatch(/in \w+/);
+
+      try {
+        fatalExit(testMessage, testCode);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ExitError);
+        expect((error as ExitError).code).toBe(testCode);
+        expect((error as ExitError).message).toBe(testMessage);
+        expect((error as ExitError).isFatal()).toBe(true);
+      }
+    });
+
+    it('未定義のエラーコードでも致命的エラーログを出力し、ExitErrorを投げる', () => {
+      const testCode = 999 as TExitCode;
+      const testMessage = 'Unknown critical error';
+
+      expect(() => fatalExit(testMessage, testCode)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.FATAL);
+      expect(logMessage).toContain('[FATAL(999)] Unknown error: Unknown critical error in');
+      expect(logMessage).toMatch(/in \w+/);
+
+      try {
+        fatalExit(testMessage, testCode);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ExitError);
+        expect((error as ExitError).code).toBe(testCode);
+        expect((error as ExitError).message).toBe(testMessage);
+        expect((error as ExitError).isFatal()).toBe(true);
+      }
+    });
+
+    it('複数回呼び出しでも正常に動作する', () => {
+      const testCases = [
+        { code: ExitCode.INVALID_ARGS, message: 'First fatal error' },
+        { code: ExitCode.EXEC_FAILURE, message: 'Second fatal error' },
+        { code: ExitCode.FILE_IO_ERROR, message: 'Third fatal error' },
+      ];
+
+      testCases.forEach(({ code, message }) => {
+        expect(() => fatalExit(message, code)).toThrow(ExitError);
+      });
+
+      const fatalMessages = mockLogger.getMessages(AgLogLevelCode.FATAL);
+      expect(fatalMessages).toHaveLength(3);
+      expect(fatalMessages[0]).toContain('[FATAL(13)] Invalid command line arguments: First fatal error in');
+      expect(fatalMessages[1]).toContain('[FATAL(1)] General execution failure: Second fatal error in');
+      expect(fatalMessages[2]).toContain('[FATAL(15)] File I/O operation failed: Third fatal error in');
+    });
+
+    it('空のメッセージでも正常に動作する', () => {
+      const testMessage = '';
+
+      expect(() => fatalExit(testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.FATAL);
+      expect(logMessage).toContain('[FATAL(1)] General execution failure:');
+      expect(logMessage).toMatch(/in \w+/);
+    });
+
+    it('長いメッセージでも正常に動作する', () => {
+      const testCode = ExitCode.EXEC_FAILURE;
+      const testMessage = 'B'.repeat(1000);
+
+      expect(() => fatalExit(testMessage, testCode)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.FATAL);
+      expect(logMessage).toContain(`[FATAL(1)] General execution failure: ${testMessage} in`);
+      expect(logMessage).toMatch(/in \w+/);
+    });
+  });
+
+  describe('agLoggerとの統合テスト', () => {
+    it('getLoggerが正しく呼び出される', () => {
+      const testMessage = 'Test fatal message';
+
+      expect(() => fatalExit(testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.FATAL);
+      expect(logMessage).toContain('[FATAL(1)] General execution failure: Test fatal message in');
+      expect(logMessage).toMatch(/in \w+/);
+    });
+
+    it('logger.fatalが正しいフォーマットで呼び出される', () => {
+      const testMessage = 'critical-config.json not found';
+
+      expect(() => fatalExit(testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.FATAL);
+      expect(logMessage).toContain('[FATAL(1)] General execution failure: critical-config.json not found in');
+      expect(logMessage).toMatch(/in \w+/);
+    });
+  });
+
+  describe('errorExitとの違いの確認', () => {
+    it('fatalExitで生成されるExitErrorのisFatalはtrueである', () => {
+      const testMessage = 'Test fatal message';
+
+      try {
+        fatalExit(testMessage);
+      } catch (error) {
+        expect((error as ExitError).isFatal()).toBe(true);
+      }
+    });
+
+    it('logger.fatalメソッドが使用される（logger.errorではない）', () => {
+      const testMessage = 'Test fatal message';
+
+      expect(() => fatalExit(testMessage)).toThrow(ExitError);
+
+      const logMessage = mockLogger.getLastMessage(AgLogLevelCode.FATAL);
+      expect(logMessage).toContain('[FATAL(1)] General execution failure: Test fatal message in');
+      expect(logMessage).toMatch(/in \w+/);
+    });
+  });
+});

--- a/packages/@esta-error/error-handler/tsconfig.json
+++ b/packages/@esta-error/error-handler/tsconfig.json
@@ -1,0 +1,38 @@
+// src: ./tsconfig.json
+// @(#) : typescript compile settings
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+{
+  "extends": "../../../base/configs/tsconfig.base.json",
+  "include": [
+    "src/**/*.ts",
+    "shared/**/*.ts",
+    "tests/**/*.ts"
+  ],
+  "exclude": [
+    ".git",
+    "lib",
+    "module",
+    "node_modules",
+    ".cache",
+    "temp"
+  ],
+  "compilerOptions": {
+    // directories
+    "outDir": "lib",
+    "rootDir": "./",
+    // alias
+    "baseUrl": "./",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    // types
+    // cache
+    "tsBuildInfoFile": ".cache/tsbuild-cache/tsbuildinfo"
+  }
+}

--- a/packages/@esta-error/error-result/.vscode/cspell.json
+++ b/packages/@esta-error/error-result/.vscode/cspell.json
@@ -1,0 +1,24 @@
+// @(#) : cspell settings for this workspace
+/**
+ *
+ * @version  1.0.0
+ * @author   Furukawa, Atsushi <https://github.com/atsushifx>
+ * @since    2025-02-27
+ * @license  MIT
+ *
+ * @description<<
+ *
+ * this file is cspell (Code Spell Checker) settings for this workspace.
+ *
+ *<<
+ */
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/packages/cspell-types/cspell.schema.json",
+  "version": "0.2",
+  "import": [
+    "${env:XDG_CONFIG_HOME}/vscode/cspell.config.json",
+    "../../../../.vscode/cspell.json"
+  ],
+  "language": "en",
+  "caseSensitive": true
+}

--- a/packages/@esta-error/error-result/configs/commitlint.config.ts
+++ b/packages/@esta-error/error-result/configs/commitlint.config.ts
@@ -1,0 +1,23 @@
+// src: commitlint.config.ts
+// @(#) : commitlint configuration for this workspace
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Commitlint configuration type definitions
+import type { UserConfig } from '@commitlint/types';
+// Base commitlint configuration
+import { default as baseConfig } from '../../../../base/configs/commitlint.config.base';
+
+const config: UserConfig = {
+  ...baseConfig,
+  rules: {
+    ...baseConfig.rules,
+    // write rules if necessary
+    // 'header-max-length': [2, 'always', 72], etc
+  },
+};
+
+export default config;

--- a/packages/@esta-error/error-result/configs/eslint.config.js
+++ b/packages/@esta-error/error-result/configs/eslint.config.js
@@ -1,0 +1,33 @@
+// src: configs/eslint.config.js
+// @(#) : ESLint flat config for TypeScript workspace
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// libs
+
+// import form common base config
+import baseConfig from '../../../../base/configs/eslint.config.base.js';
+
+// settings
+export default [
+  ...baseConfig,
+
+  // source code settings
+  {
+    files: [
+      'src/**/*.ts',
+      'shared/**/*.ts',
+      'tests/**/*.ts',
+    ],
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
+  },
+];

--- a/packages/@esta-error/error-result/configs/eslint.config.typed.js
+++ b/packages/@esta-error/error-result/configs/eslint.config.typed.js
@@ -1,0 +1,41 @@
+// src: configs/eslint.config.typed.js
+// @(#) : eslint float config for type check
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// parser
+import tsparser from '@typescript-eslint/parser';
+
+// import form common base config
+import baseConfig from '../../../../base/configs/eslint.config.typed.base.js';
+
+export default [
+  ...baseConfig,
+  // --- source code
+  // source codes settings
+  {
+    files: [
+      'src/**/*.ts',
+      'shared/**/*.ts',
+      'tests/**/*.ts',
+    ],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        project: ['./tsconfig.json'],
+        tsconfigRootDir: '.',
+        sourceType: 'module',
+      },
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
+  },
+];

--- a/packages/@esta-error/error-result/configs/secretlint.config.yaml
+++ b/packages/@esta-error/error-result/configs/secretlint.config.yaml
@@ -1,0 +1,10 @@
+# src: shared/configs/secretlint.config.base.yaml
+# @(#) : secretlint base configuration
+#
+# Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+rules:
+  - id: "@secretlint/secretlint-rule-preset-recommend"

--- a/packages/@esta-error/error-result/configs/tsup.config.module.ts
+++ b/packages/@esta-error/error-result/configs/tsup.config.module.ts
@@ -1,0 +1,23 @@
+// src: configs/tsup.config.module.ts
+// @(#) : tsup config for esm module
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Build configuration utility
+import { defineConfig } from 'tsup';
+// Base build configuration
+import { baseConfig } from '../../../../base/configs/tsup.config.base';
+
+// configs
+export default defineConfig({
+  ...baseConfig,
+
+  // sub-packages definition
+  format: ['esm'],
+  outDir: 'module', // for ESM
+  // tsconfig
+  tsconfig: './tsconfig.json',
+});

--- a/packages/@esta-error/error-result/configs/tsup.config.ts
+++ b/packages/@esta-error/error-result/configs/tsup.config.ts
@@ -1,0 +1,22 @@
+// src: configs/tsup.config.ts
+// @(#) : tsup config for CommonJS module
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Build configuration utility
+import { defineConfig } from 'tsup';
+// Base build configuration
+import { baseConfig } from '../../../../base/configs/tsup.config.base';
+
+export default defineConfig({
+  ...baseConfig,
+
+  // sub packages definition
+  format: ['cjs'],
+  outDir: 'lib', // for CJS
+  // tsconfig
+  tsconfig: './tsconfig.json',
+});

--- a/packages/@esta-error/error-result/configs/vitest.config.e2e.ts
+++ b/packages/@esta-error/error-result/configs/vitest.config.e2e.ts
@@ -26,6 +26,10 @@ export default mergeConfig(baseConfig, {
       'tests/e2e/**/*.test.ts',
       'tests/e2e/**/*.spec.ts',
     ],
+    exclude: [
+      '**/__tests__/+.spec.ts',
+      '**/__tests__/+.test.ts',
+    ],
     caches: {
       dir: path.resolve(__dirname, '../../../.cache/vitest-cache/e2e/'),
     },

--- a/packages/@esta-error/error-result/configs/vitest.config.e2e.ts
+++ b/packages/@esta-error/error-result/configs/vitest.config.e2e.ts
@@ -1,0 +1,41 @@
+// src: shared/common/configs/vitest.config.e2e.ts
+// @(#) : vitest config for end-to-end test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Path utilities for directory resolution
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Vitest configuration utilities
+import { mergeConfig } from 'vitest/config';
+// Base vitest configuration
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // CI (End-to-End) Tests
+      'tests/e2e/**/*.test.ts',
+      'tests/e2e/**/*.spec.ts',
+    ],
+    caches: {
+      dir: path.resolve(__dirname, '../../../.cache/vitest-cache/e2e/'),
+    },
+    sequence: {
+      concurrent: true,
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../src'),
+    },
+  },
+});

--- a/packages/@esta-error/error-result/configs/vitest.config.integration.ts
+++ b/packages/@esta-error/error-result/configs/vitest.config.integration.ts
@@ -1,0 +1,40 @@
+// src: shared/common/configs/vitest.config.integration.ts
+// @(#) : vitest config for integration test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Path utilities for directory resolution
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Vitest configuration utilities
+import { mergeConfig } from 'vitest/config';
+// Base vitest configuration
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // CI (Integration) Tests
+      'tests/integration/**/*.test.ts',
+      'tests/integration/**/*.spec.ts',
+    ],
+    caches: {
+      dir: path.resolve(__dirname, '../../../.cache/vitest-cache/integration/'),
+    },
+    sequence: {
+      concurrent: true,
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../src'),
+    },
+  },
+});

--- a/packages/@esta-error/error-result/configs/vitest.config.integration.ts
+++ b/packages/@esta-error/error-result/configs/vitest.config.integration.ts
@@ -25,6 +25,10 @@ export default mergeConfig(baseConfig, {
       'tests/integration/**/*.test.ts',
       'tests/integration/**/*.spec.ts',
     ],
+    exclude: [
+      '**/__tests__/+.spec.ts',
+      '**/__tests__/+.test.ts',
+    ],
     caches: {
       dir: path.resolve(__dirname, '../../../.cache/vitest-cache/integration/'),
     },

--- a/packages/@esta-error/error-result/configs/vitest.config.unit.ts
+++ b/packages/@esta-error/error-result/configs/vitest.config.unit.ts
@@ -22,8 +22,8 @@ export default mergeConfig(baseConfig, {
   test: {
     include: [
       // Unit Test (develop test) exec only sub repositories
-      'src/**/*.test.ts',
-      'src/**/*.spec.ts',
+      'src/**/__tests__/*.test.ts',
+      'src/**/__tests__/*.spec.ts',
     ],
     caches: {
       dir: path.resolve(__dirname, '../../../.cache/vitest-cache/unit/'),

--- a/packages/@esta-error/error-result/configs/vitest.config.unit.ts
+++ b/packages/@esta-error/error-result/configs/vitest.config.unit.ts
@@ -1,0 +1,40 @@
+// src: shared/common/configs/vitest.config.unit.ts
+// @(#) : vitest config for unit test
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Path utilities for directory resolution
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+// base directory
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Vitest configuration utilities
+import { mergeConfig } from 'vitest/config';
+// Base vitest configuration
+import baseConfig from '../../../../base/configs/vitest.config.base';
+
+// config
+export default mergeConfig(baseConfig, {
+  test: {
+    include: [
+      // Unit Test (develop test) exec only sub repositories
+      'src/**/*.test.ts',
+      'src/**/*.spec.ts',
+    ],
+    caches: {
+      dir: path.resolve(__dirname, '../../../.cache/vitest-cache/unit/'),
+    },
+    sequence: {
+      concurrent: false, // Unit tests are run sequentially to avoid conflicts
+    },
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '../src'),
+    },
+  },
+});

--- a/packages/@esta-error/error-result/package.json
+++ b/packages/@esta-error/error-result/package.json
@@ -47,7 +47,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@esta-core/error-handler": "workspace:*",
+    "@esta-error/error-handler": "workspace:*",
     "@shared/constants": "workspace:*"
   },
   "devDependencies": {}

--- a/packages/@esta-error/error-result/package.json
+++ b/packages/@esta-error/error-result/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@esta-error/error-result",
+  "_comment": "@(#) @esta-error: ESTA Error Result Handler",
+  "private": true,
+  "version": "0.0.0",
+  "description": "ErrorResultクラスとタプル型エラーハンドリングを提供するパッケージ",
+  "author": "atsushifx <https://github.com/atsushifx>",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./lib/index.js",
+  "module": "./module/index.js",
+  "types": "./module/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./module/index.d.ts",
+      "import": "./module/index.js",
+      "require": "./lib/index.cjs"
+    }
+  },
+  "files": [
+    "lib",
+    "module"
+  ],
+  "scripts": {
+    "build": "pnpm run build:cjs && pnpm run build:esm",
+    "build:cjs": "tsup --config ./configs/tsup.config.ts",
+    "build:esm": "tsup --config ./configs/tsup.config.module.ts",
+    "clean": "rimraf lib module .cache",
+    "format:dprint": "dprint fmt",
+    "check:dprint": "dprint check",
+    "check:types": "tsc --noEmit --incremental",
+    "check:spells": "cspell --config .vscode/cspell.json --cache --cache-location ../../../.cache/cspell/cSpellCache",
+    "lint": "pnpm exec eslint --config ./configs/eslint.config.js --cache --cache-location ../../../.cache/eslint-cache/esLintCache ",
+    "lint:types": "pnpm exec eslint --config ./configs/eslint.config.typed.js --cache --cache-location ../../../.cache/eslint-cache/esLintCache",
+    "lint:all": "pnpm run lint && pnpm run lint:types",
+    "lint:fix": "pnpm run lint --fix",
+    "lint:secrets": "secretlint --secretlintrc ./configs/secretlint.config.yaml --secretlintignore .gitignore --maskSecrets **/*",
+    "test:all": "pnpm run test:develop && pnpm run test:ci && pnpm run test:e2e",
+    "test:develop": "pnpm exec vitest run --config ./configs/vitest.config.unit.ts",
+    "test:ci": "pnpm exec vitest run --config ./configs/vitest.config.integration.ts",
+    "test:e2e": "pnpm exec vitest run --config ./configs/vitest.config.e2e.ts",
+    "sync:configs": "bash ../../../scripts/sync-configs.sh . "
+  },
+  "engines": {
+    "pnpm": ">=10",
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@esta-core/error-handler": "workspace:*",
+    "@shared/constants": "workspace:*"
+  },
+  "devDependencies": {}
+}

--- a/packages/@esta-error/error-result/shared/constants/errorCode.constants.ts
+++ b/packages/@esta-error/error-result/shared/constants/errorCode.constants.ts
@@ -1,3 +1,14 @@
+// src: shared/constants/errorCode.constants.ts
+// @(#) : error code constants for error-result package
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/**
+ * Predefined error codes for common error scenarios
+ */
 export const ERROR_CODES = {
   PROMISE_REJECTED: 'PROMISE_REJECTED',
   CALLBACK_ERROR: 'CALLBACK_ERROR',
@@ -5,4 +16,7 @@ export const ERROR_CODES = {
   TEST_ERROR: 'TEST_ERROR',
 } as const;
 
+/**
+ * Type representing all possible error code values
+ */
 export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];

--- a/packages/@esta-error/error-result/shared/constants/errorCode.constants.ts
+++ b/packages/@esta-error/error-result/shared/constants/errorCode.constants.ts
@@ -1,0 +1,8 @@
+export const ERROR_CODES = {
+  PROMISE_REJECTED: 'PROMISE_REJECTED',
+  CALLBACK_ERROR: 'CALLBACK_ERROR',
+  CUSTOM_ERROR: 'CUSTOM_ERROR',
+  TEST_ERROR: 'TEST_ERROR',
+} as const;
+
+export type ErrorCode = typeof ERROR_CODES[keyof typeof ERROR_CODES];

--- a/packages/@esta-error/error-result/shared/constants/index.ts
+++ b/packages/@esta-error/error-result/shared/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './errorCode.constants';

--- a/packages/@esta-error/error-result/shared/constants/index.ts
+++ b/packages/@esta-error/error-result/shared/constants/index.ts
@@ -1,1 +1,9 @@
+// src: shared/constants/index.ts
+// @(#) : constants export for error-result package
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 export * from './errorCode.constants';

--- a/packages/@esta-error/error-result/shared/types/errorResult.types.ts
+++ b/packages/@esta-error/error-result/shared/types/errorResult.types.ts
@@ -1,3 +1,14 @@
+// src: shared/types/errorResult.types.ts
+// @(#) : type definitions for ErrorResult
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/**
+ * JSON representation of an ErrorResult for serialization
+ */
 export type ErrorResultJSON = {
   name: string;
   code: string;
@@ -7,6 +18,9 @@ export type ErrorResultJSON = {
   recoverable: boolean;
 };
 
+/**
+ * Options for configuring ErrorResult behavior
+ */
 export type ErrorResultOptions = {
   recoverable?: boolean;
 };

--- a/packages/@esta-error/error-result/shared/types/errorResult.types.ts
+++ b/packages/@esta-error/error-result/shared/types/errorResult.types.ts
@@ -1,0 +1,12 @@
+export type ErrorResultJSON = {
+  name: string;
+  code: string;
+  message: string;
+  context?: Record<string, unknown>;
+  timestamp: string;
+  recoverable: boolean;
+};
+
+export type ErrorResultOptions = {
+  recoverable?: boolean;
+};

--- a/packages/@esta-error/error-result/shared/types/index.ts
+++ b/packages/@esta-error/error-result/shared/types/index.ts
@@ -1,2 +1,10 @@
+// src: shared/types/index.ts
+// @(#) : type definitions export for error-result package
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
 export * from './errorResult.types';
 export * from './tupleResult.types';

--- a/packages/@esta-error/error-result/shared/types/index.ts
+++ b/packages/@esta-error/error-result/shared/types/index.ts
@@ -1,0 +1,2 @@
+export * from './errorResult.types';
+export * from './tupleResult.types';

--- a/packages/@esta-error/error-result/shared/types/tupleResult.types.ts
+++ b/packages/@esta-error/error-result/shared/types/tupleResult.types.ts
@@ -1,0 +1,3 @@
+import type { ErrorResult } from '@/errors/ErrorResult';
+
+export type TupleResult<T, E = ErrorResult> = [T, undefined] | [undefined, E];

--- a/packages/@esta-error/error-result/shared/types/tupleResult.types.ts
+++ b/packages/@esta-error/error-result/shared/types/tupleResult.types.ts
@@ -1,3 +1,18 @@
+// src: shared/types/tupleResult.types.ts
+// @(#) : type definitions for tuple-based error handling
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// ErrorResult class type for tuple result pattern
 import type { ErrorResult } from '@/errors/ErrorResult';
 
+/**
+ * Tuple result type for error handling patterns
+ * Returns either [result, undefined] for success or [undefined, error] for failure
+ * @template T - The type of the successful result
+ * @template E - The type of the error (defaults to ErrorResult)
+ */
 export type TupleResult<T, E = ErrorResult> = [T, undefined] | [undefined, E];

--- a/packages/@esta-error/error-result/src/__tests__/ErrorResultFactory.spec.ts
+++ b/packages/@esta-error/error-result/src/__tests__/ErrorResultFactory.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// モックを事前に設定
+vi.mock('@esta-core/error-handler', () => ({
+  fatalExit: vi.fn(() => {
+    throw new Error('Fatal exit called');
+  }),
+}));
+
+vi.mock('@shared/constants', () => ({
+  ExitCode: {
+    EXEC_FAILURE: 1,
+  },
+}));
+
+import { fatalExit } from '@esta-core/error-handler';
+import { ErrorResultFactory } from '../handlers/ErrorResultFactory';
+
+describe('ErrorResultFactory', () => {
+  let factory: ErrorResultFactory;
+
+  beforeEach(() => {
+    factory = new ErrorResultFactory();
+    vi.clearAllMocks();
+  });
+
+  describe('error method', () => {
+    it('should create recoverable error', () => {
+      const error = factory.error('TEST_ERROR', 'Test message');
+
+      expect(error.code).toBe('TEST_ERROR');
+      expect(error.message).toBe('Test message');
+      expect(error.recoverable).toBe(true);
+    });
+
+    it('should create error with context', () => {
+      const context = { userId: 123 };
+      const error = factory.error('TEST_ERROR', 'Test message', context);
+
+      expect(error.context).toEqual(context);
+    });
+  });
+
+  describe('fatal method', () => {
+    it('should call fatalExit with correct parameters', () => {
+      expect(() => {
+        factory.fatal('FATAL_ERROR', 'Fatal message');
+      }).toThrow('Fatal exit called');
+
+      expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
+    });
+  });
+});

--- a/packages/@esta-error/error-result/src/__tests__/ErrorResultFactory.spec.ts
+++ b/packages/@esta-error/error-result/src/__tests__/ErrorResultFactory.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // モックを事前に設定
-vi.mock('@esta-core/error-handler', () => ({
+vi.mock('@esta-error/error-handler', () => ({
   fatalExit: vi.fn(() => {
     throw new Error('Fatal exit called');
   }),
@@ -13,7 +13,7 @@ vi.mock('@shared/constants', () => ({
   },
 }));
 
-import { fatalExit } from '@esta-core/error-handler';
+import { fatalExit } from '@esta-error/error-handler';
 import { ErrorResultFactory } from '../handlers/ErrorResultFactory';
 
 describe('ErrorResultFactory', () => {

--- a/packages/@esta-error/error-result/src/__tests__/TupleResult.spec.ts
+++ b/packages/@esta-error/error-result/src/__tests__/TupleResult.spec.ts
@@ -61,7 +61,7 @@ describe('TupleResult', () => {
 
   describe('wrapCallback', () => {
     it('should convert successful callback to success tuple', async () => {
-      const fn = (callback: (error: Error | null, result?: string) => void) => {
+      const fn = (callback: (error: Error | null, result?: string) => void): void => {
         callback(null, 'success');
       };
 
@@ -72,7 +72,7 @@ describe('TupleResult', () => {
     });
 
     it('should convert error callback to error tuple', async () => {
-      const fn = (callback: (error: Error | null, result?: string) => void) => {
+      const fn = (callback: (error: Error | null, result?: string) => void): void => {
         callback(new Error('Callback failed'));
       };
 

--- a/packages/@esta-error/error-result/src/__tests__/TupleResult.spec.ts
+++ b/packages/@esta-error/error-result/src/__tests__/TupleResult.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { ErrorResult } from '../errors/ErrorResult';
+import type { TupleResult } from '../handlers/TupleResult';
+import { toTupleResult, wrapCallback } from '../handlers/TupleResult';
+
+describe('TupleResult', () => {
+  describe('TupleResult type', () => {
+    it('should define success tuple correctly', () => {
+      const successTuple: TupleResult<string> = ['success', undefined];
+
+      expect(successTuple[0]).toBe('success');
+      expect(successTuple[1]).toBeUndefined();
+    });
+
+    it('should define error tuple correctly', () => {
+      const error = new ErrorResult('TEST_ERROR', 'Test message');
+      const errorTuple: TupleResult<string> = [undefined, error];
+
+      expect(errorTuple[0]).toBeUndefined();
+      expect(errorTuple[1]).toBeInstanceOf(ErrorResult);
+    });
+  });
+
+  describe('toTupleResult', () => {
+    it('should convert successful promise to success tuple', async () => {
+      const promise = Promise.resolve('success');
+      const [result, error] = await toTupleResult(promise);
+
+      expect(result).toBe('success');
+      expect(error).toBeUndefined();
+    });
+
+    it('should convert rejected promise to error tuple', async () => {
+      const promise = Promise.reject(new Error('Promise failed'));
+      const [result, error] = await toTupleResult(promise);
+
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(ErrorResult);
+      expect(error?.code).toBe('PROMISE_REJECTED');
+      expect(error?.message).toBe('Promise failed');
+    });
+
+    it('should handle ErrorResult rejection correctly', async () => {
+      const originalError = new ErrorResult('CUSTOM_ERROR', 'Custom message');
+      const promise = Promise.reject(originalError);
+      const [result, error] = await toTupleResult(promise);
+
+      expect(result).toBeUndefined();
+      expect(error).toBe(originalError);
+    });
+
+    it('should handle non-Error rejection', async () => {
+      const promise = Promise.reject('string error');
+      const [result, error] = await toTupleResult(promise);
+
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(ErrorResult);
+      expect(error?.message).toBe('string error');
+    });
+  });
+
+  describe('wrapCallback', () => {
+    it('should convert successful callback to success tuple', async () => {
+      const fn = (callback: (error: Error | null, result?: string) => void) => {
+        callback(null, 'success');
+      };
+
+      const [result, error] = await wrapCallback(fn);
+
+      expect(result).toBe('success');
+      expect(error).toBeUndefined();
+    });
+
+    it('should convert error callback to error tuple', async () => {
+      const fn = (callback: (error: Error | null, result?: string) => void) => {
+        callback(new Error('Callback failed'));
+      };
+
+      const [result, error] = await wrapCallback(fn);
+
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(ErrorResult);
+      expect(error?.code).toBe('CALLBACK_ERROR');
+      expect(error?.message).toBe('Callback failed');
+    });
+  });
+});

--- a/packages/@esta-error/error-result/src/__tests__/errorResult.spec.ts
+++ b/packages/@esta-error/error-result/src/__tests__/errorResult.spec.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// モックを事前に設定
+vi.mock('@esta-core/error-handler', () => ({
+  fatalExit: vi.fn(() => {
+    throw new Error('Fatal exit called');
+  }),
+}));
+
+vi.mock('@shared/constants', () => ({
+  ExitCode: {
+    EXEC_FAILURE: 1,
+  },
+}));
+
+import { fatalExit } from '@esta-core/error-handler';
+import { errorResult } from '../handlers/ErrorResultFactory';
+
+describe('errorResult singleton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('singleton existence', () => {
+    it('should be defined', () => {
+      expect(errorResult).toBeDefined();
+    });
+
+    it('should have error method', () => {
+      expect(errorResult.error).toBeDefined();
+      expect(typeof errorResult.error).toBe('function');
+    });
+
+    it('should have fatal method', () => {
+      expect(errorResult.fatal).toBeDefined();
+      expect(typeof errorResult.fatal).toBe('function');
+    });
+  });
+
+  describe('error method', () => {
+    it('should create ErrorResult instances correctly', () => {
+      const error = errorResult.error('TEST_ERROR', 'Test message');
+
+      expect(error.code).toBe('TEST_ERROR');
+      expect(error.message).toBe('Test message');
+      expect(error.recoverable).toBe(true);
+      expect(error.name).toBe('ErrorResult');
+      expect(error.timestamp).toBeInstanceOf(Date);
+    });
+
+    it('should create error with context', () => {
+      const context = { userId: 123, operation: 'test' };
+      const error = errorResult.error('TEST_ERROR', 'Test message', context);
+
+      expect(error.code).toBe('TEST_ERROR');
+      expect(error.message).toBe('Test message');
+      expect(error.context).toEqual(context);
+      expect(error.recoverable).toBe(true);
+    });
+
+    it('should create error without context', () => {
+      const error = errorResult.error('TEST_ERROR', 'Test message');
+
+      expect(error.code).toBe('TEST_ERROR');
+      expect(error.message).toBe('Test message');
+      expect(error.context).toBeUndefined();
+      expect(error.recoverable).toBe(true);
+    });
+  });
+
+  describe('fatal method', () => {
+    it('should call fatalExit properly', () => {
+      expect(() => {
+        errorResult.fatal('FATAL_ERROR', 'Fatal message');
+      }).toThrow('Fatal exit called');
+
+      expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
+      expect(fatalExit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call fatalExit with context', () => {
+      const context = { error: 'critical', system: 'main' };
+
+      expect(() => {
+        errorResult.fatal('FATAL_ERROR', 'Fatal message', context);
+      }).toThrow('Fatal exit called');
+
+      expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
+      expect(fatalExit).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/@esta-error/error-result/src/__tests__/errorResult.spec.ts
+++ b/packages/@esta-error/error-result/src/__tests__/errorResult.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // モックを事前に設定
-vi.mock('@esta-core/error-handler', () => ({
+vi.mock('@esta-error/error-handler', () => ({
   fatalExit: vi.fn(() => {
     throw new Error('Fatal exit called');
   }),
@@ -13,7 +13,7 @@ vi.mock('@shared/constants', () => ({
   },
 }));
 
-import { fatalExit } from '@esta-core/error-handler';
+import { fatalExit } from '@esta-error/error-handler';
 import { errorResult } from '../handlers/ErrorResultFactory';
 
 describe('errorResult singleton', () => {

--- a/packages/@esta-error/error-result/src/errors/ErrorResult.ts
+++ b/packages/@esta-error/error-result/src/errors/ErrorResult.ts
@@ -1,0 +1,42 @@
+import type { ErrorResultJSON, ErrorResultOptions } from '../../shared/types';
+
+export class ErrorResult extends Error {
+  public readonly code: string;
+  public readonly context?: Record<string, unknown>;
+  public readonly timestamp: Date;
+  public readonly recoverable: boolean;
+
+  constructor(
+    code: string,
+    message: string,
+    context?: Record<string, unknown>,
+    options?: ErrorResultOptions,
+  ) {
+    super(message);
+
+    this.name = 'ErrorResult';
+    this.code = code;
+    this.context = context;
+    this.timestamp = new Date();
+    this.recoverable = options?.recoverable ?? true;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ErrorResult);
+    }
+  }
+
+  toJSON(): ErrorResultJSON {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      context: this.context,
+      timestamp: this.timestamp.toISOString(),
+      recoverable: this.recoverable,
+    };
+  }
+
+  isRecoverable(): boolean {
+    return this.recoverable;
+  }
+}

--- a/packages/@esta-error/error-result/src/errors/ErrorResult.ts
+++ b/packages/@esta-error/error-result/src/errors/ErrorResult.ts
@@ -1,16 +1,36 @@
+// src: errors/ErrorResult.ts
+// @(#) : ErrorResult class for structured error handling
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Type definitions for ErrorResult class
 import type { ErrorResultJSON, ErrorResultOptions } from '../../shared/types';
 
+/**
+ * ErrorResult class extends Error to provide structured error handling
+ * with additional context, error codes, and recovery information.
+ */
 export class ErrorResult extends Error {
   public readonly code: string;
   public readonly context?: Record<string, unknown>;
   public readonly timestamp: Date;
   public readonly recoverable: boolean;
 
+  /**
+   * Creates a new ErrorResult instance
+   * @param code - Error code identifier
+   * @param message - Error message
+   * @param context - Additional context data
+   * @param options - Error options including recovery flag
+   */
   constructor(
     code: string,
     message: string,
     context?: Record<string, unknown>,
-    options?: ErrorResultOptions,
+    options?: { recoverable?: boolean },
   ) {
     super(message);
 
@@ -20,11 +40,15 @@ export class ErrorResult extends Error {
     this.timestamp = new Date();
     this.recoverable = options?.recoverable ?? true;
 
-    if (Error.captureStackTrace) {
+    if (typeof Error.captureStackTrace === 'function') {
       Error.captureStackTrace(this, ErrorResult);
     }
   }
 
+  /**
+   * Converts the ErrorResult to a JSON-serializable object
+   * @returns JSON representation of the error
+   */
   toJSON(): ErrorResultJSON {
     return {
       name: this.name,
@@ -36,6 +60,10 @@ export class ErrorResult extends Error {
     };
   }
 
+  /**
+   * Checks if the error is recoverable
+   * @returns true if the error is recoverable, false otherwise
+   */
   isRecoverable(): boolean {
     return this.recoverable;
   }

--- a/packages/@esta-error/error-result/src/errors/ErrorResult.ts
+++ b/packages/@esta-error/error-result/src/errors/ErrorResult.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // Type definitions for ErrorResult class
-import type { ErrorResultJSON, ErrorResultOptions } from '../../shared/types';
+import type { ErrorResultJSON } from '../../shared/types';
 
 /**
  * ErrorResult class extends Error to provide structured error handling

--- a/packages/@esta-error/error-result/src/errors/TupleResult.ts
+++ b/packages/@esta-error/error-result/src/errors/TupleResult.ts
@@ -1,0 +1,32 @@
+import { ERROR_CODES } from '../../shared/constants';
+import type { TupleResult } from '../../shared/types';
+import { ErrorResult } from './ErrorResult';
+
+export const toTupleResult = async <T>(
+  promise: Promise<T>,
+): Promise<TupleResult<T>> => {
+  try {
+    const result = await promise;
+    return [result, undefined];
+  } catch (error) {
+    const errorResult = error instanceof ErrorResult
+      ? error
+      : new ErrorResult(ERROR_CODES.PROMISE_REJECTED, error instanceof Error ? error.message : String(error));
+    return [undefined, errorResult];
+  }
+};
+
+export const wrapCallback = <T>(
+  fn: (callback: (error: Error | null, result?: T) => void) => void,
+): Promise<TupleResult<T>> => {
+  return new Promise((resolve) => {
+    fn((error, result) => {
+      if (error) {
+        const errorResult = new ErrorResult(ERROR_CODES.CALLBACK_ERROR, error.message);
+        resolve([undefined, errorResult]);
+      } else {
+        resolve([result as T, undefined]);
+      }
+    });
+  });
+};

--- a/packages/@esta-error/error-result/src/errors/TupleResult.ts
+++ b/packages/@esta-error/error-result/src/errors/TupleResult.ts
@@ -1,7 +1,23 @@
+// src: errors/TupleResult.ts
+// @(#) : utility functions for tuple-based error handling
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Error codes for tuple result handling
 import { ERROR_CODES } from '../../shared/constants';
+// Type definition for tuple result pattern
 import type { TupleResult } from '../../shared/types';
+// ErrorResult class for error handling
 import { ErrorResult } from './ErrorResult';
 
+/**
+ * Converts a Promise to a tuple result format [result, error]
+ * @param promise - The promise to convert
+ * @returns A tuple with either [result, undefined] or [undefined, error]
+ */
 export const toTupleResult = async <T>(
   promise: Promise<T>,
 ): Promise<TupleResult<T>> => {
@@ -16,6 +32,11 @@ export const toTupleResult = async <T>(
   }
 };
 
+/**
+ * Wraps a callback-based function to return a Promise with tuple result
+ * @param fn - Callback-based function to wrap
+ * @returns Promise resolving to tuple result
+ */
 export const wrapCallback = <T>(
   fn: (callback: (error: Error | null, result?: T) => void) => void,
 ): Promise<TupleResult<T>> => {

--- a/packages/@esta-error/error-result/src/errors/__tests__/TupleResult.spec.ts
+++ b/packages/@esta-error/error-result/src/errors/__tests__/TupleResult.spec.ts
@@ -111,7 +111,7 @@ describe('TupleResult', () => {
      */
     describe('successful callback conversion', () => {
       it('should convert successful callback to success tuple', async () => {
-        const fn = (callback: (error: Error | null, result?: string) => void) => {
+        const fn = (callback: (error: Error | null, result?: string) => void): void => {
           callback(null, 'success');
         };
 
@@ -127,7 +127,7 @@ describe('TupleResult', () => {
      */
     describe('error callback conversion', () => {
       it('should convert error callback to error tuple', async () => {
-        const fn = (callback: (error: Error | null, result?: string) => void) => {
+        const fn = (callback: (error: Error | null, result?: string) => void): void => {
           callback(new Error('Callback failed'));
         };
 

--- a/packages/@esta-error/error-result/src/errors/__tests__/TupleResult.spec.ts
+++ b/packages/@esta-error/error-result/src/errors/__tests__/TupleResult.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { TupleResult } from '../../../shared/types';
+import { ERROR_CODES, ErrorResult, toTupleResult, wrapCallback } from '../..';
+
+describe('TupleResult', () => {
+  describe('TupleResult type', () => {
+    it('should define success tuple correctly', () => {
+      const successTuple: TupleResult<string> = ['success', undefined];
+
+      expect(successTuple[0]).toBe('success');
+      expect(successTuple[1]).toBeUndefined();
+    });
+
+    it('should define error tuple correctly', () => {
+      const error = new ErrorResult(ERROR_CODES.TEST_ERROR, 'Test message');
+      const errorTuple: TupleResult<string> = [undefined, error];
+
+      expect(errorTuple[0]).toBeUndefined();
+      expect(errorTuple[1]).toBeInstanceOf(ErrorResult);
+    });
+  });
+
+  describe('toTupleResult', () => {
+    it('should convert successful promise to success tuple', async () => {
+      const promise = Promise.resolve('success');
+      const [result, error] = await toTupleResult(promise);
+
+      expect(result).toBe('success');
+      expect(error).toBeUndefined();
+    });
+
+    it('should convert rejected promise to error tuple', async () => {
+      const promise = Promise.reject(new Error('Promise failed'));
+      const [result, error] = await toTupleResult(promise);
+
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(ErrorResult);
+      expect(error?.code).toBe(ERROR_CODES.PROMISE_REJECTED);
+      expect(error?.message).toBe('Promise failed');
+    });
+
+    it('should handle ErrorResult rejection correctly', async () => {
+      const originalError = new ErrorResult(ERROR_CODES.CUSTOM_ERROR, 'Custom message');
+      const promise = Promise.reject(originalError);
+      const [result, error] = await toTupleResult(promise);
+
+      expect(result).toBeUndefined();
+      expect(error).toBe(originalError);
+    });
+
+    it('should handle non-Error rejection', async () => {
+      const promise = Promise.reject('string error');
+      const [result, error] = await toTupleResult(promise);
+
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(ErrorResult);
+      expect(error?.message).toBe('string error');
+    });
+  });
+
+  describe('wrapCallback', () => {
+    it('should convert successful callback to success tuple', async () => {
+      const fn = (callback: (error: Error | null, result?: string) => void) => {
+        callback(null, 'success');
+      };
+
+      const [result, error] = await wrapCallback(fn);
+
+      expect(result).toBe('success');
+      expect(error).toBeUndefined();
+    });
+
+    it('should convert error callback to error tuple', async () => {
+      const fn = (callback: (error: Error | null, result?: string) => void) => {
+        callback(new Error('Callback failed'));
+      };
+
+      const [result, error] = await wrapCallback(fn);
+
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(ErrorResult);
+      expect(error?.code).toBe(ERROR_CODES.CALLBACK_ERROR);
+      expect(error?.message).toBe('Callback failed');
+    });
+  });
+});

--- a/packages/@esta-error/error-result/src/errors/__tests__/TupleResult.spec.ts
+++ b/packages/@esta-error/error-result/src/errors/__tests__/TupleResult.spec.ts
@@ -1,86 +1,143 @@
+// src: errors/__tests__/TupleResult.spec.ts
+// @(#) : unit tests for TupleResult type and utility functions
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Vitest testing framework
 import { describe, expect, it } from 'vitest';
+// TupleResult type definition
 import type { TupleResult } from '../../../shared/types';
+// Error codes, classes, and utility functions
 import { ERROR_CODES, ErrorResult, toTupleResult, wrapCallback } from '../..';
 
+/**
+ * Test suite for TupleResult type and related utility functions
+ * Tests tuple-based error handling pattern with [result, error] structure
+ */
 describe('TupleResult', () => {
+  /**
+   * Tests for TupleResult type definition
+   * Verifies correct tuple structure for success and error cases
+   */
   describe('TupleResult type', () => {
-    it('should define success tuple correctly', () => {
-      const successTuple: TupleResult<string> = ['success', undefined];
+    /**
+     * Tests for success tuple structure
+     */
+    describe('success tuple structure', () => {
+      it('should define success tuple correctly', () => {
+        const successTuple: TupleResult<string> = ['success', undefined];
 
-      expect(successTuple[0]).toBe('success');
-      expect(successTuple[1]).toBeUndefined();
+        expect(successTuple[0]).toBe('success');
+        expect(successTuple[1]).toBeUndefined();
+      });
     });
 
-    it('should define error tuple correctly', () => {
-      const error = new ErrorResult(ERROR_CODES.TEST_ERROR, 'Test message');
-      const errorTuple: TupleResult<string> = [undefined, error];
+    /**
+     * Tests for error tuple structure
+     */
+    describe('error tuple structure', () => {
+      it('should define error tuple correctly', () => {
+        const error = new ErrorResult(ERROR_CODES.TEST_ERROR, 'Test message');
+        const errorTuple: TupleResult<string> = [undefined, error];
 
-      expect(errorTuple[0]).toBeUndefined();
-      expect(errorTuple[1]).toBeInstanceOf(ErrorResult);
+        expect(errorTuple[0]).toBeUndefined();
+        expect(errorTuple[1]).toBeInstanceOf(ErrorResult);
+      });
     });
   });
 
+  /**
+   * Tests for toTupleResult utility function
+   * Verifies conversion of promises to tuple format
+   */
   describe('toTupleResult', () => {
-    it('should convert successful promise to success tuple', async () => {
-      const promise = Promise.resolve('success');
-      const [result, error] = await toTupleResult(promise);
+    /**
+     * Tests for successful promise conversion
+     */
+    describe('successful promise conversion', () => {
+      it('should convert successful promise to success tuple', async () => {
+        const promise = Promise.resolve('success');
+        const [result, error] = await toTupleResult(promise);
 
-      expect(result).toBe('success');
-      expect(error).toBeUndefined();
+        expect(result).toBe('success');
+        expect(error).toBeUndefined();
+      });
     });
 
-    it('should convert rejected promise to error tuple', async () => {
-      const promise = Promise.reject(new Error('Promise failed'));
-      const [result, error] = await toTupleResult(promise);
+    /**
+     * Tests for rejected promise conversion
+     */
+    describe('rejected promise conversion', () => {
+      it('should convert rejected promise to error tuple', async () => {
+        const promise = Promise.reject(new Error('Promise failed'));
+        const [result, error] = await toTupleResult(promise);
 
-      expect(result).toBeUndefined();
-      expect(error).toBeInstanceOf(ErrorResult);
-      expect(error?.code).toBe(ERROR_CODES.PROMISE_REJECTED);
-      expect(error?.message).toBe('Promise failed');
-    });
+        expect(result).toBeUndefined();
+        expect(error).toBeInstanceOf(ErrorResult);
+        expect(error?.code).toBe(ERROR_CODES.PROMISE_REJECTED);
+        expect(error?.message).toBe('Promise failed');
+      });
 
-    it('should handle ErrorResult rejection correctly', async () => {
-      const originalError = new ErrorResult(ERROR_CODES.CUSTOM_ERROR, 'Custom message');
-      const promise = Promise.reject(originalError);
-      const [result, error] = await toTupleResult(promise);
+      it('should handle ErrorResult rejection correctly', async () => {
+        const originalError = new ErrorResult(ERROR_CODES.CUSTOM_ERROR, 'Custom message');
+        const promise = Promise.reject(originalError);
+        const [result, error] = await toTupleResult(promise);
 
-      expect(result).toBeUndefined();
-      expect(error).toBe(originalError);
-    });
+        expect(result).toBeUndefined();
+        expect(error).toBe(originalError);
+      });
 
-    it('should handle non-Error rejection', async () => {
-      const promise = Promise.reject('string error');
-      const [result, error] = await toTupleResult(promise);
+      it('should handle non-Error rejection', async () => {
+        const promise = Promise.reject('string error');
+        const [result, error] = await toTupleResult(promise);
 
-      expect(result).toBeUndefined();
-      expect(error).toBeInstanceOf(ErrorResult);
-      expect(error?.message).toBe('string error');
+        expect(result).toBeUndefined();
+        expect(error).toBeInstanceOf(ErrorResult);
+        expect(error?.message).toBe('string error');
+      });
     });
   });
 
+  /**
+   * Tests for wrapCallback utility function
+   * Verifies conversion of Node.js-style callbacks to tuple format
+   */
   describe('wrapCallback', () => {
-    it('should convert successful callback to success tuple', async () => {
-      const fn = (callback: (error: Error | null, result?: string) => void) => {
-        callback(null, 'success');
-      };
+    /**
+     * Tests for successful callback conversion
+     */
+    describe('successful callback conversion', () => {
+      it('should convert successful callback to success tuple', async () => {
+        const fn = (callback: (error: Error | null, result?: string) => void) => {
+          callback(null, 'success');
+        };
 
-      const [result, error] = await wrapCallback(fn);
+        const [result, error] = await wrapCallback(fn);
 
-      expect(result).toBe('success');
-      expect(error).toBeUndefined();
+        expect(result).toBe('success');
+        expect(error).toBeUndefined();
+      });
     });
 
-    it('should convert error callback to error tuple', async () => {
-      const fn = (callback: (error: Error | null, result?: string) => void) => {
-        callback(new Error('Callback failed'));
-      };
+    /**
+     * Tests for error callback conversion
+     */
+    describe('error callback conversion', () => {
+      it('should convert error callback to error tuple', async () => {
+        const fn = (callback: (error: Error | null, result?: string) => void) => {
+          callback(new Error('Callback failed'));
+        };
 
-      const [result, error] = await wrapCallback(fn);
+        const [result, error] = await wrapCallback(fn);
 
-      expect(result).toBeUndefined();
-      expect(error).toBeInstanceOf(ErrorResult);
-      expect(error?.code).toBe(ERROR_CODES.CALLBACK_ERROR);
-      expect(error?.message).toBe('Callback failed');
+        expect(result).toBeUndefined();
+        expect(error).toBeInstanceOf(ErrorResult);
+        expect(error?.code).toBe(ERROR_CODES.CALLBACK_ERROR);
+        expect(error?.message).toBe('Callback failed');
+      });
     });
   });
 });

--- a/packages/@esta-error/error-result/src/errors/__tests__/errorResult.spec.ts
+++ b/packages/@esta-error/error-result/src/errors/__tests__/errorResult.spec.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// モックを事前に設定
+vi.mock('@esta-core/error-handler', () => ({
+  fatalExit: vi.fn(() => {
+    throw new Error('Fatal exit called');
+  }),
+}));
+
+vi.mock('@shared/constants', () => ({
+  ExitCode: {
+    EXEC_FAILURE: 1,
+  },
+}));
+
+import { fatalExit } from '@esta-core/error-handler';
+import { ERROR_CODES, errorResult } from '../..';
+
+describe('errorResult singleton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('singleton existence', () => {
+    it('should be defined', () => {
+      expect(errorResult).toBeDefined();
+    });
+
+    it('should have error method', () => {
+      expect(errorResult.error).toBeDefined();
+      expect(typeof errorResult.error).toBe('function');
+    });
+
+    it('should have fatal method', () => {
+      expect(errorResult.fatal).toBeDefined();
+      expect(typeof errorResult.fatal).toBe('function');
+    });
+  });
+
+  describe('error method', () => {
+    it('should create ErrorResult instances correctly', () => {
+      const error = errorResult.error(ERROR_CODES.TEST_ERROR, 'Test message');
+
+      expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
+      expect(error.message).toBe('Test message');
+      expect(error.recoverable).toBe(true);
+      expect(error.name).toBe('ErrorResult');
+      expect(error.timestamp).toBeInstanceOf(Date);
+    });
+
+    it('should create error with context', () => {
+      const context = { userId: 123, operation: 'test' };
+      const error = errorResult.error(ERROR_CODES.TEST_ERROR, 'Test message', context);
+
+      expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
+      expect(error.message).toBe('Test message');
+      expect(error.context).toEqual(context);
+      expect(error.recoverable).toBe(true);
+    });
+
+    it('should create error without context', () => {
+      const error = errorResult.error(ERROR_CODES.TEST_ERROR, 'Test message');
+
+      expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
+      expect(error.message).toBe('Test message');
+      expect(error.context).toBeUndefined();
+      expect(error.recoverable).toBe(true);
+    });
+  });
+
+  describe('fatal method', () => {
+    it('should call fatalExit properly', () => {
+      expect(() => {
+        errorResult.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message');
+      }).toThrow('Fatal exit called');
+
+      expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
+      expect(fatalExit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call fatalExit with context', () => {
+      const context = { error: 'critical', system: 'main' };
+
+      expect(() => {
+        errorResult.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message', context);
+      }).toThrow('Fatal exit called');
+
+      expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
+      expect(fatalExit).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/@esta-error/error-result/src/errors/__tests__/errorResult.spec.ts
+++ b/packages/@esta-error/error-result/src/errors/__tests__/errorResult.spec.ts
@@ -10,7 +10,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // モックを事前に設定
-vi.mock('@esta-core/error-handler', () => ({
+vi.mock('@esta-error/error-handler', () => ({
   fatalExit: vi.fn(() => {
     throw new Error('Fatal exit called');
   }),
@@ -23,7 +23,7 @@ vi.mock('@shared/constants', () => ({
 }));
 
 // Fatal error handler utility
-import { fatalExit } from '@esta-core/error-handler';
+import { fatalExit } from '@esta-error/error-handler';
 // Error codes and singleton instance
 import { ERROR_CODES, errorResult } from '../..';
 
@@ -120,7 +120,7 @@ describe('errorResult singleton', () => {
           errorResult.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message');
         }).toThrow('Fatal exit called');
 
-        expect(fatalExit).toHaveBeenCalledWith('Fatal message', 1);
+        expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
         expect(fatalExit).toHaveBeenCalledTimes(1);
       });
 
@@ -131,7 +131,7 @@ describe('errorResult singleton', () => {
           errorResult.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message', context);
         }).toThrow('Fatal exit called');
 
-        expect(fatalExit).toHaveBeenCalledWith('Fatal message', 1);
+        expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
         expect(fatalExit).toHaveBeenCalledTimes(1);
       });
     });

--- a/packages/@esta-error/error-result/src/errors/__tests__/errorResult.spec.ts
+++ b/packages/@esta-error/error-result/src/errors/__tests__/errorResult.spec.ts
@@ -1,3 +1,12 @@
+// src: errors/__tests__/errorResult.spec.ts
+// @(#) : unit tests for errorResult singleton instance
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Vitest testing framework
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // モックを事前に設定
@@ -13,80 +22,118 @@ vi.mock('@shared/constants', () => ({
   },
 }));
 
+// Fatal error handler utility
 import { fatalExit } from '@esta-core/error-handler';
+// Error codes and singleton instance
 import { ERROR_CODES, errorResult } from '../..';
 
+/**
+ * Test suite for errorResult singleton
+ * Tests the default ErrorResultFactory instance for creating errors and handling fatal conditions
+ */
 describe('errorResult singleton', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
+  /**
+   * Tests for singleton instance existence and structure
+   * Verifies that the singleton is properly instantiated and has required methods
+   */
   describe('singleton existence', () => {
-    it('should be defined', () => {
-      expect(errorResult).toBeDefined();
-    });
+    /**
+     * Tests for basic singleton structure
+     */
+    describe('basic structure', () => {
+      it('should be defined', () => {
+        expect(errorResult).toBeDefined();
+      });
 
-    it('should have error method', () => {
-      expect(errorResult.error).toBeDefined();
-      expect(typeof errorResult.error).toBe('function');
-    });
+      it('should have error method', () => {
+        expect(errorResult.error).toBeDefined();
+        expect(typeof errorResult.error).toBe('function');
+      });
 
-    it('should have fatal method', () => {
-      expect(errorResult.fatal).toBeDefined();
-      expect(typeof errorResult.fatal).toBe('function');
+      it('should have fatal method', () => {
+        expect(errorResult.fatal).toBeDefined();
+        expect(typeof errorResult.fatal).toBe('function');
+      });
     });
   });
 
+  /**
+   * Tests for the error method
+   * Verifies creation of recoverable ErrorResult instances through singleton
+   */
   describe('error method', () => {
-    it('should create ErrorResult instances correctly', () => {
-      const error = errorResult.error(ERROR_CODES.TEST_ERROR, 'Test message');
+    /**
+     * Tests for basic error creation functionality
+     */
+    describe('basic error creation', () => {
+      it('should create ErrorResult instances correctly', () => {
+        const error = errorResult.error(ERROR_CODES.TEST_ERROR, 'Test message');
 
-      expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
-      expect(error.message).toBe('Test message');
-      expect(error.recoverable).toBe(true);
-      expect(error.name).toBe('ErrorResult');
-      expect(error.timestamp).toBeInstanceOf(Date);
+        expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
+        expect(error.message).toBe('Test message');
+        expect(error.recoverable).toBe(true);
+        expect(error.name).toBe('ErrorResult');
+        expect(error.timestamp).toBeInstanceOf(Date);
+      });
     });
 
-    it('should create error with context', () => {
-      const context = { userId: 123, operation: 'test' };
-      const error = errorResult.error(ERROR_CODES.TEST_ERROR, 'Test message', context);
+    /**
+     * Tests for error creation with context data
+     */
+    describe('error creation with context', () => {
+      it('should create error with context', () => {
+        const context = { userId: 123, operation: 'test' };
+        const error = errorResult.error(ERROR_CODES.TEST_ERROR, 'Test message', context);
 
-      expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
-      expect(error.message).toBe('Test message');
-      expect(error.context).toEqual(context);
-      expect(error.recoverable).toBe(true);
-    });
+        expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
+        expect(error.message).toBe('Test message');
+        expect(error.context).toEqual(context);
+        expect(error.recoverable).toBe(true);
+      });
 
-    it('should create error without context', () => {
-      const error = errorResult.error(ERROR_CODES.TEST_ERROR, 'Test message');
+      it('should create error without context', () => {
+        const error = errorResult.error(ERROR_CODES.TEST_ERROR, 'Test message');
 
-      expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
-      expect(error.message).toBe('Test message');
-      expect(error.context).toBeUndefined();
-      expect(error.recoverable).toBe(true);
+        expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
+        expect(error.message).toBe('Test message');
+        expect(error.context).toBeUndefined();
+        expect(error.recoverable).toBe(true);
+      });
     });
   });
 
+  /**
+   * Tests for the fatal method
+   * Verifies fatal error handling and process exit behavior through singleton
+   */
   describe('fatal method', () => {
-    it('should call fatalExit properly', () => {
-      expect(() => {
-        errorResult.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message');
-      }).toThrow('Fatal exit called');
+    /**
+     * Tests for fatal error processing
+     */
+    describe('fatal error processing', () => {
+      it('should call fatalExit properly', () => {
+        expect(() => {
+          errorResult.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message');
+        }).toThrow('Fatal exit called');
 
-      expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
-      expect(fatalExit).toHaveBeenCalledTimes(1);
-    });
+        expect(fatalExit).toHaveBeenCalledWith('Fatal message', 1);
+        expect(fatalExit).toHaveBeenCalledTimes(1);
+      });
 
-    it('should call fatalExit with context', () => {
-      const context = { error: 'critical', system: 'main' };
+      it('should call fatalExit with context', () => {
+        const context = { error: 'critical', system: 'main' };
 
-      expect(() => {
-        errorResult.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message', context);
-      }).toThrow('Fatal exit called');
+        expect(() => {
+          errorResult.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message', context);
+        }).toThrow('Fatal exit called');
 
-      expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
-      expect(fatalExit).toHaveBeenCalledTimes(1);
+        expect(fatalExit).toHaveBeenCalledWith('Fatal message', 1);
+        expect(fatalExit).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/packages/@esta-error/error-result/src/handlers/ErrorResultFactory.ts
+++ b/packages/@esta-error/error-result/src/handlers/ErrorResultFactory.ts
@@ -1,0 +1,46 @@
+// src: handlers/ErrorResultFactory.ts
+// @(#) : factory class for creating ErrorResult instances
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Fatal error handler utility
+import { fatalExit } from '@esta-core/error-handler';
+// Exit code constants
+import { ExitCode } from '@shared/constants';
+// ErrorResult class for error handling
+import { ErrorResult } from '../errors/ErrorResult';
+
+/**
+ * Factory class for creating ErrorResult instances and handling fatal errors
+ */
+export class ErrorResultFactory {
+  /**
+   * Creates a recoverable ErrorResult instance
+   * @param code - Error code identifier
+   * @param message - Error message
+   * @param context - Additional context data
+   * @returns New ErrorResult instance
+   */
+  error(code: string, message: string, context?: Record<string, unknown>): ErrorResult {
+    return new ErrorResult(code, message, context, { recoverable: true });
+  }
+
+  /**
+   * Creates a fatal error and exits the process
+   * @param code - Error code identifier
+   * @param message - Error message
+   * @param _context - Additional context data (unused)
+   * @returns Never returns, exits the process
+   */
+  fatal(code: string, message: string, _context?: Record<string, unknown>): never {
+    return fatalExit(ExitCode.EXEC_FAILURE, message);
+  }
+}
+
+/**
+ * Default instance of ErrorResultFactory for convenient usage
+ */
+export const errorResult = new ErrorResultFactory();

--- a/packages/@esta-error/error-result/src/handlers/ErrorResultFactory.ts
+++ b/packages/@esta-error/error-result/src/handlers/ErrorResultFactory.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // Fatal error handler utility
-import { fatalExit } from '@esta-core/error-handler';
+import { fatalExit } from '@esta-error/error-handler';
 // Exit code constants
 import { ExitCode } from '@shared/constants';
 // ErrorResult class for error handling

--- a/packages/@esta-error/error-result/src/handlers/TupleResult.ts
+++ b/packages/@esta-error/error-result/src/handlers/TupleResult.ts
@@ -1,0 +1,32 @@
+import { ErrorResult } from '../errors/ErrorResult';
+
+export type TupleResult<T, E = ErrorResult> = [T, undefined] | [undefined, E];
+
+export const toTupleResult = async <T>(
+  promise: Promise<T>,
+): Promise<TupleResult<T>> => {
+  try {
+    const result = await promise;
+    return [result, undefined];
+  } catch (error) {
+    const errorResult = error instanceof ErrorResult
+      ? error
+      : new ErrorResult('PROMISE_REJECTED', error instanceof Error ? error.message : String(error));
+    return [undefined, errorResult];
+  }
+};
+
+export const wrapCallback = <T>(
+  fn: (callback: (error: Error | null, result?: T) => void) => void,
+): Promise<TupleResult<T>> => {
+  return new Promise((resolve) => {
+    fn((error, result) => {
+      if (error) {
+        const errorResult = new ErrorResult('CALLBACK_ERROR', error.message);
+        resolve([undefined, errorResult]);
+      } else {
+        resolve([result as T, undefined]);
+      }
+    });
+  });
+};

--- a/packages/@esta-error/error-result/src/handlers/__tests__/ErrorResultFactory.spec.ts
+++ b/packages/@esta-error/error-result/src/handlers/__tests__/ErrorResultFactory.spec.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// モックを事前に設定
+vi.mock('@esta-core/error-handler', () => ({
+  fatalExit: vi.fn(() => {
+    throw new Error('Fatal exit called');
+  }),
+}));
+
+vi.mock('@shared/constants', () => ({
+  ExitCode: {
+    EXEC_FAILURE: 1,
+  },
+}));
+
+import { fatalExit } from '@esta-core/error-handler';
+import { ERROR_CODES, ErrorResultFactory } from '../..';
+
+describe('ErrorResultFactory', () => {
+  let factory: ErrorResultFactory;
+
+  beforeEach(() => {
+    factory = new ErrorResultFactory();
+    vi.clearAllMocks();
+  });
+
+  describe('error method', () => {
+    it('should create recoverable error', () => {
+      const error = factory.error(ERROR_CODES.TEST_ERROR, 'Test message');
+
+      expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
+      expect(error.message).toBe('Test message');
+      expect(error.recoverable).toBe(true);
+    });
+
+    it('should create error with context', () => {
+      const context = { userId: 123 };
+      const error = factory.error(ERROR_CODES.TEST_ERROR, 'Test message', context);
+
+      expect(error.context).toEqual(context);
+    });
+  });
+
+  describe('fatal method', () => {
+    it('should call fatalExit with correct parameters', () => {
+      expect(() => {
+        factory.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message');
+      }).toThrow('Fatal exit called');
+
+      expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
+    });
+  });
+});

--- a/packages/@esta-error/error-result/src/handlers/__tests__/ErrorResultFactory.spec.ts
+++ b/packages/@esta-error/error-result/src/handlers/__tests__/ErrorResultFactory.spec.ts
@@ -10,7 +10,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // モックを事前に設定
-vi.mock('@esta-core/error-handler', () => ({
+vi.mock('@esta-error/error-handler', () => ({
   fatalExit: vi.fn(() => {
     throw new Error('Fatal exit called');
   }),
@@ -23,7 +23,7 @@ vi.mock('@shared/constants', () => ({
 }));
 
 // Fatal error handler utility
-import { fatalExit } from '@esta-core/error-handler';
+import { fatalExit } from '@esta-error/error-handler';
 // Error codes and factory class
 import { ERROR_CODES, ErrorResultFactory } from '../..';
 
@@ -84,7 +84,7 @@ describe('ErrorResultFactory', () => {
           factory.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message');
         }).toThrow('Fatal exit called');
 
-        expect(fatalExit).toHaveBeenCalledWith('Fatal message', 1);
+        expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
       });
     });
   });

--- a/packages/@esta-error/error-result/src/handlers/__tests__/ErrorResultFactory.spec.ts
+++ b/packages/@esta-error/error-result/src/handlers/__tests__/ErrorResultFactory.spec.ts
@@ -1,3 +1,12 @@
+// src: handlers/__tests__/ErrorResultFactory.spec.ts
+// @(#) : unit tests for ErrorResultFactory class
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// Vitest testing framework
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // モックを事前に設定
@@ -13,9 +22,15 @@ vi.mock('@shared/constants', () => ({
   },
 }));
 
+// Fatal error handler utility
 import { fatalExit } from '@esta-core/error-handler';
+// Error codes and factory class
 import { ERROR_CODES, ErrorResultFactory } from '../..';
 
+/**
+ * Test suite for ErrorResultFactory class
+ * Tests factory methods for creating ErrorResult instances and handling fatal errors
+ */
 describe('ErrorResultFactory', () => {
   let factory: ErrorResultFactory;
 
@@ -24,30 +39,53 @@ describe('ErrorResultFactory', () => {
     vi.clearAllMocks();
   });
 
+  /**
+   * Tests for the error method
+   * Verifies creation of recoverable ErrorResult instances
+   */
   describe('error method', () => {
-    it('should create recoverable error', () => {
-      const error = factory.error(ERROR_CODES.TEST_ERROR, 'Test message');
+    /**
+     * Tests for basic error creation functionality
+     */
+    describe('basic error creation', () => {
+      it('should create recoverable error', () => {
+        const error = factory.error(ERROR_CODES.TEST_ERROR, 'Test message');
 
-      expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
-      expect(error.message).toBe('Test message');
-      expect(error.recoverable).toBe(true);
+        expect(error.code).toBe(ERROR_CODES.TEST_ERROR);
+        expect(error.message).toBe('Test message');
+        expect(error.recoverable).toBe(true);
+      });
     });
 
-    it('should create error with context', () => {
-      const context = { userId: 123 };
-      const error = factory.error(ERROR_CODES.TEST_ERROR, 'Test message', context);
+    /**
+     * Tests for error creation with context data
+     */
+    describe('error creation with context', () => {
+      it('should create error with context', () => {
+        const context = { userId: 123 };
+        const error = factory.error(ERROR_CODES.TEST_ERROR, 'Test message', context);
 
-      expect(error.context).toEqual(context);
+        expect(error.context).toEqual(context);
+      });
     });
   });
 
+  /**
+   * Tests for the fatal method
+   * Verifies fatal error handling and process exit behavior
+   */
   describe('fatal method', () => {
-    it('should call fatalExit with correct parameters', () => {
-      expect(() => {
-        factory.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message');
-      }).toThrow('Fatal exit called');
+    /**
+     * Tests for fatal error processing
+     */
+    describe('fatal error processing', () => {
+      it('should call fatalExit with correct parameters', () => {
+        expect(() => {
+          factory.fatal(ERROR_CODES.TEST_ERROR, 'Fatal message');
+        }).toThrow('Fatal exit called');
 
-      expect(fatalExit).toHaveBeenCalledWith(1, 'Fatal message');
+        expect(fatalExit).toHaveBeenCalledWith('Fatal message', 1);
+      });
     });
   });
 });

--- a/packages/@esta-error/error-result/src/index.ts
+++ b/packages/@esta-error/error-result/src/index.ts
@@ -1,5 +1,17 @@
+// src: index.ts
+// @(#) : main entry point for error-result package
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// export constants
 export * from '../shared/constants';
+// export types and interfaces
 export * from '../shared/types';
+// export function results
 export * from './errors/ErrorResult';
 export * from './errors/TupleResult';
+// export factories
 export * from './handlers/ErrorResultFactory';

--- a/packages/@esta-error/error-result/src/index.ts
+++ b/packages/@esta-error/error-result/src/index.ts
@@ -1,0 +1,5 @@
+export * from '../shared/constants';
+export * from '../shared/types';
+export * from './errors/ErrorResult';
+export * from './errors/TupleResult';
+export * from './handlers/ErrorResultFactory';

--- a/packages/@esta-error/error-result/tsconfig.json
+++ b/packages/@esta-error/error-result/tsconfig.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@shared/*": ["../../../shared/packages/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [

--- a/packages/@esta-error/error-result/tsconfig.json
+++ b/packages/@esta-error/error-result/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../../base/configs/tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@shared/*": ["../../../shared/packages/*"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "shared/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib",
+    "module",
+    ".cache"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,12 +141,22 @@ importers:
       '@shared/constants':
         specifier: workspace:*
         version: link:../../../shared/packages/constants
+    devDependencies:
+      '@actions/core':
+        specifier: ^1.11.1
+        version: 1.11.1
+      '@actions/exec':
+        specifier: ^1.1.1
+        version: 1.1.1
+      '@actions/http-client':
+        specifier: ^2.2.3
+        version: 2.2.3
 
   packages/@esta-error/error-result:
     dependencies:
-      '@esta-core/error-handler':
+      '@esta-error/error-handler':
         specifier: workspace:*
-        version: link:../../@esta-core/error-handler
+        version: link:../error-handler
       '@shared/constants':
         specifier: workspace:*
         version: link:../../../shared/packages/constants

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 5.8.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0))
+        version: 5.1.4(typescript@5.8.3)(vite@7.0.6(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
@@ -112,15 +112,6 @@ importers:
         specifier: workspace:*
         version: link:../../../shared/packages/constants
 
-  packages/@esta-core/esta-config:
-    dependencies:
-      '@esta-utils/config-loader':
-        specifier: workspace:*
-        version: link:../../@esta-utils/config-loader
-      valibot:
-        specifier: ^1.1.0
-        version: 1.1.0(typescript@5.8.3)
-
   packages/@esta-core/feature-flags:
     devDependencies:
       '@shared/constants':
@@ -141,6 +132,24 @@ importers:
       valibot:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.8.3)
+
+  packages/@esta-error/error-handler:
+    dependencies:
+      '@agla-utils/ag-logger':
+        specifier: workspace:*
+        version: link:../../@agla-utils/ag-logger
+      '@shared/constants':
+        specifier: workspace:*
+        version: link:../../../shared/packages/constants
+
+  packages/@esta-error/error-result:
+    dependencies:
+      '@esta-core/error-handler':
+        specifier: workspace:*
+        version: link:../../@esta-core/error-handler
+      '@shared/constants':
+        specifier: workspace:*
+        version: link:../../../shared/packages/constants
 
   packages/@esta-system/exit-status:
     dependencies:
@@ -1546,8 +1555,8 @@ packages:
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
-  loupe@3.1.4:
-    resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
+  loupe@3.2.0:
+    resolution: {integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2089,8 +2098,8 @@ packages:
       vite:
         optional: true
 
-  vite@7.0.5:
-    resolution: {integrity: sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==}
+  vite@7.0.6:
+    resolution: {integrity: sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2707,13 +2716,13 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.0.5(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.0.5(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -2738,7 +2747,7 @@ snapshots:
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
-      loupe: 3.1.4
+      loupe: 3.2.0
       tinyrainbow: 2.0.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
@@ -2876,7 +2885,7 @@ snapshots:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.4
+      loupe: 3.2.0
       pathval: 2.0.1
 
   chalk@4.1.2:
@@ -3604,7 +3613,7 @@ snapshots:
 
   lodash.sortby@4.7.0: {}
 
-  loupe@3.1.4: {}
+  loupe@3.2.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -4202,7 +4211,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.5(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4217,18 +4226,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.6(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
-      vite: 7.0.5(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.0.5(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0):
+  vite@7.0.6(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.3)
@@ -4246,7 +4255,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.5(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -4264,7 +4273,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.5(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
       vite-node: 3.2.4(@types/node@22.16.5)(tsx@4.20.3)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## ✨ Overview

This PR introduces `ErrorResult` as a structured error-return mechanism for function execution.  
In addition, it refactors shared types/constants under `/shared`, improves error test coverage, and documents both source and test files with JSDoc.

This work is part of the ESTA Phase 1 restructuring effort to unify error handling and project structure across packages.

---

## 🔧 Changes

List the key changes included in this PR:

- [x] Added/updated files or modules
- [x] Removed deprecated logic or configs
- [x] Refactored for clarity/performance
- [ ] Other (please describe below)

---

## 📂 Related Issues

> Related to #118
> Related to internal roadmap item "error system unification"

---

## ✅ Checklist

Please confirm the following before requesting review:

- [x] Lint checks pass (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

- Implemented `ErrorResult` for consistent error handling
- Added fallback support via `typeof Error.captureStackTrace`
- Added header comments and JSDoc to both implementation and test files
- Centralized shared types and constants to improve structure and maintainability
