### PR TITLE
refactor: improve AgLogger creation and path aliasing for cleaner API usage

### DIFF
--- a/packages/@agla-utils/ag-logger/docs/pure-functions.spec.md
+++ b/packages/@agla-utils/ag-logger/docs/pure-functions.spec.md
@@ -62,7 +62,7 @@ const formatLogMessage = (
 
 ```typescript
 // 実装は LogLevelHelpers.ts を参照
-import { AgToLabel, AgToLogLevel } from '../../src/utils/LogLevelHelpers';
+import { AgToLabel, AgToLogLevel } from '@/utils/LogLevelHelpers';
 
 // AgTLogLevel (数値) → AgTLogLevelLabel (文字列ラベル) 変換
 // AgToLabel(level: AgTLogLevel): AgTLogLevelLabel

--- a/packages/@agla-utils/ag-logger/shared/types/AgLogger.interface.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgLogger.interface.ts
@@ -63,3 +63,37 @@ export type AgFormatFunction = (logMessage: AgLogMessage) => string;
  * ```
  */
 export type AgLoggerMap<T extends AgLoggerFunction = AgLoggerFunction> = Record<AgTLogLevel, T | null>;
+
+/**
+ * Configuration options for AgLogger and AgLoggerManager instances.
+ * Used to configure default logger, formatter, and logger map for different log levels.
+ *
+ * @example
+ * ```typescript
+ * const options: AgLoggerOptions = {
+ *   defaultLogger: ConsoleLogger,
+ *   formatter: JsonFormat,
+ *   loggerMap: {
+ *     [AG_LOGLEVEL.ERROR]: (msg) => console.error(msg),
+ *     [AG_LOGLEVEL.WARN]: (msg) => console.warn(msg)
+ *   }
+ * };
+ * ```
+ */
+export type AgLoggerOptions = {
+  /**
+   * Default logger function to use for all log levels unless overridden by loggerMap.
+   */
+  defaultLogger?: AgLoggerFunction;
+
+  /**
+   * Formatter function to format log messages before passing to logger functions.
+   */
+  formatter?: AgFormatFunction;
+
+  /**
+   * Partial map of logger functions for specific log levels.
+   * Overrides defaultLogger for specified levels.
+   */
+  loggerMap?: Partial<AgLoggerMap<AgLoggerFunction>>;
+};

--- a/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
@@ -10,7 +10,7 @@
 import { AG_LOGLEVEL } from '../shared/types';
 import type { AgTLogLevel } from '../shared/types';
 // interfaces
-import type { AgFormatFunction, AgLoggerFunction, AgLoggerMap } from '../shared/types/AgLogger.interface';
+import type { AgLoggerOptions } from '../shared/types/AgLogger.interface';
 
 // core
 import { AgLoggerManager } from './AgLoggerManager.class';
@@ -36,23 +36,17 @@ export class AgLogger {
 
   /**
    * Returns the singleton instance of AgLogger,
-   * optionally accepting a default logger, formatter, and logger map.
+   * optionally accepting configuration options.
    *
-   * @param defaultLogger - Optional default logger function.
-   * @param formatter - Optional formatter function.
-   * @param loggerMap - Optional partial logger map for log levels.
+   * @param options - Optional configuration options for logger setup.
    * @returns The singleton AgLogger instance.
    */
-  static getLogger(
-    defaultLogger?: AgLoggerFunction,
-    formatter?: AgFormatFunction,
-    loggerMap?: Partial<AgLoggerMap<AgLoggerFunction>>,
-  ): AgLogger {
+  static getLogger(options?: AgLoggerOptions): AgLogger {
     const instance = (AgLogger._instance ??= new AgLogger());
 
     // If configuration is passed, delegate to setManager for unified handling
-    if (defaultLogger !== undefined || formatter !== undefined || loggerMap !== undefined) {
-      instance.setManager({ defaultLogger, formatter, loggerMap });
+    if (options !== undefined) {
+      instance.setManager(options);
     }
 
     return instance;
@@ -133,13 +127,9 @@ export class AgLogger {
    * If ConsoleLogger is specified without a logger map,
    * ConsoleLoggerMap will be automatically applied.
    *
-   * @param options - Configuration options including defaultLogger, formatter, and loggerMap.
+   * @param options - Configuration options for the logger.
    */
-  setManager(options: {
-    defaultLogger?: AgLoggerFunction;
-    formatter?: AgFormatFunction;
-    loggerMap?: Partial<AgLoggerMap<AgLoggerFunction>>;
-  }): void {
+  setManager(options: AgLoggerOptions): void {
     const enhancedOptions = { ...options };
     if (options.defaultLogger === ConsoleLogger && !options.loggerMap) {
       enhancedOptions.loggerMap = ConsoleLoggerMap;
@@ -204,21 +194,15 @@ export class AgLogger {
  * If ConsoleLogger is specified as default without a logger map,
  * ConsoleLoggerMap is automatically applied.
  *
- * @param defaultLogger - Optional default logger function.
- * @param formatter - Optional formatter function.
- * @param loggerMap - Optional partial logger map.
+ * @param options - Optional configuration options for the logger.
  * @returns The singleton AgLogger instance.
  */
-export const getLogger = (
-  defaultLogger?: AgLoggerFunction,
-  formatter?: AgFormatFunction,
-  loggerMap?: Partial<AgLoggerMap<AgLoggerFunction>>,
-): AgLogger => {
-  if (defaultLogger === ConsoleLogger && !loggerMap) {
-    loggerMap = ConsoleLoggerMap;
+export const getLogger = (options?: AgLoggerOptions): AgLogger => {
+  if (options?.defaultLogger === ConsoleLogger && !options.loggerMap) {
+    options = { ...options, loggerMap: ConsoleLoggerMap };
   }
 
-  return AgLogger.getLogger(defaultLogger, formatter, loggerMap);
+  return AgLogger.getLogger(options);
 };
 
 export default AgLogger;

--- a/packages/@agla-utils/ag-logger/src/AgLoggerManager.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLoggerManager.class.ts
@@ -9,7 +9,12 @@
 // types
 import { AG_LOGLEVEL } from '../shared/types';
 import type { AgTLogLevel } from '../shared/types';
-import type { AgFormatFunction, AgLoggerFunction, AgLoggerMap } from '../shared/types/AgLogger.interface';
+import type {
+  AgFormatFunction,
+  AgLoggerFunction,
+  AgLoggerMap,
+  AgLoggerOptions,
+} from '../shared/types/AgLogger.interface';
 
 // plugins
 import { NullFormat } from '@/plugins/format/NullFormat';
@@ -41,31 +46,25 @@ export class AgLoggerManager {
 
   /**
    * Returns the singleton instance of AgLoggerManager.
-   * Optionally sets default logger, formatter, and/or logger map on first initialization.
+   * Optionally sets configuration options on first initialization.
    *
-   * @param defaultLogger - Optional default logger function.
-   * @param formatter - Optional formatter function.
-   * @param loggerMap - Optional partial map of loggers by log level.
+   * @param options - Optional configuration options for logger setup.
    * @returns The singleton instance of AgLoggerManager.
    */
-  static getManager(
-    defaultLogger?: AgLoggerFunction,
-    formatter?: AgFormatFunction,
-    loggerMap?: Partial<AgLoggerMap<AgLoggerFunction>>,
-  ): AgLoggerManager {
+  static getManager(options?: AgLoggerOptions): AgLoggerManager {
     AgLoggerManager.instance ??= new AgLoggerManager();
 
-    if (defaultLogger) {
-      AgLoggerManager.instance.defaultLogger = defaultLogger;
+    if (options?.defaultLogger) {
+      AgLoggerManager.instance.defaultLogger = options.defaultLogger;
     }
 
-    if (formatter) {
-      AgLoggerManager.instance.formatter = formatter;
+    if (options?.formatter) {
+      AgLoggerManager.instance.formatter = options.formatter;
     }
 
     // Update logger map with provided default logger or custom logger map
-    if (defaultLogger || loggerMap) {
-      AgLoggerManager.instance.updateLogMap(defaultLogger, loggerMap);
+    if (options?.defaultLogger || options?.loggerMap) {
+      AgLoggerManager.instance.updateLogMap(options.defaultLogger, options.loggerMap);
     }
 
     return AgLoggerManager.instance;
@@ -129,17 +128,9 @@ export class AgLoggerManager {
    * @param logFunction - Logger function or null (optional, only for log level overload).
    */
   setManager(logLevel: AgTLogLevel, logFunction: AgLoggerFunction | null): void;
-  setManager(options: {
-    defaultLogger?: AgLoggerFunction;
-    formatter?: AgFormatFunction;
-    loggerMap?: Partial<AgLoggerMap<AgLoggerFunction>>;
-  }): void;
+  setManager(options: AgLoggerOptions): void;
   setManager(
-    logLevelOrOptions: AgTLogLevel | {
-      defaultLogger?: AgLoggerFunction;
-      formatter?: AgFormatFunction;
-      loggerMap?: Partial<AgLoggerMap<AgLoggerFunction>>;
-    },
+    logLevelOrOptions: AgTLogLevel | AgLoggerOptions,
     logFunction?: AgLoggerFunction | null,
   ): void {
     if (typeof logLevelOrOptions === 'number') {

--- a/packages/@agla-utils/ag-logger/src/AgLoggerManager.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLoggerManager.class.ts
@@ -119,38 +119,43 @@ export class AgLoggerManager {
   }
 
   /**
-   * Sets loggers or options.
-   * Supports two overloads:
-   * - Set a logger function for a specific log level.
-   * - Set options including default logger, formatter, and logger map.
+   * Sets options including default logger, formatter, and logger map.
+   * For setting individual logger functions, use setLogFunctionWithLevel.
    *
-   * @param logLevelOrOptions - Either a log level or an options object.
-   * @param logFunction - Logger function or null (optional, only for log level overload).
+   * @param options - Configuration options for logger setup.
    */
-  setManager(logLevel: AgTLogLevel, logFunction: AgLoggerFunction | null): void;
-  setManager(options: AgLoggerOptions): void;
-  setManager(
-    logLevelOrOptions: AgTLogLevel | AgLoggerOptions,
-    logFunction?: AgLoggerFunction | null,
-  ): void {
-    if (typeof logLevelOrOptions === 'number') {
-      // Old-style: setManager(logLevel, logFunction)
-      this.loggerMap[logLevelOrOptions] = logFunction ?? this.defaultLogger;
-    } else {
-      // New-style: setManager(options)
-      const options = logLevelOrOptions;
-      if (options.defaultLogger !== undefined) {
-        this.defaultLogger = options.defaultLogger;
-      }
-      if (options.formatter !== undefined) {
-        this.formatter = options.formatter;
-      }
-
-      // Update logger map if default logger or logger map provided
-      if (options.defaultLogger || options.loggerMap) {
-        this.updateLogMap(options.defaultLogger, options.loggerMap);
-      }
+  setManager(options: AgLoggerOptions): void {
+    if (options.defaultLogger !== undefined) {
+      this.defaultLogger = options.defaultLogger;
     }
+    if (options.formatter !== undefined) {
+      this.formatter = options.formatter;
+    }
+
+    // Update logger map if default logger or logger map provided
+    if (options.defaultLogger || options.loggerMap) {
+      this.updateLogMap(options.defaultLogger, options.loggerMap);
+    }
+  }
+
+  /**
+   * Sets a specific logger function for a log level.
+   * To set a level to use the default logger, use setDefaultLogFunction instead.
+   *
+   * @param logLevel - The log level to set the logger for.
+   * @param logFunction - The logger function to set.
+   */
+  setLogFunctionWithLevel(logLevel: AgTLogLevel, logFunction: AgLoggerFunction): void {
+    this.loggerMap[logLevel] = logFunction;
+  }
+
+  /**
+   * Sets a log level to use the default logger.
+   *
+   * @param logLevel - The log level to set to default logger.
+   */
+  setDefaultLogFunction(logLevel: AgTLogLevel): void {
+    this.loggerMap[logLevel] = this.defaultLogger;
   }
 
   /**

--- a/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.spec.ts
@@ -77,7 +77,7 @@ describe('AgLogger', () => {
       });
 
       it('should maintain singleton with different parameters', () => {
-        const logger1 = AgLogger.getLogger(mockLogger, mockFormatter);
+        const logger1 = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
         const logger2 = AgLogger.getLogger();
 
         expect(logger1).toBe(logger2);
@@ -109,7 +109,7 @@ describe('AgLogger', () => {
       });
 
       it('should filter logs based on current level', () => {
-        const logger = AgLogger.getLogger(mockLogger, mockFormatter);
+        const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
         logger.setLogLevel(AG_LOGLEVEL.WARN);
 
         logger.debug('debug'); // filtered
@@ -122,7 +122,7 @@ describe('AgLogger', () => {
       });
 
       it('should block all logs when level is OFF', () => {
-        const logger = AgLogger.getLogger(mockLogger, mockFormatter);
+        const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
         logger.setLogLevel(AG_LOGLEVEL.OFF);
 
         logger.fatal('fatal');
@@ -143,7 +143,7 @@ describe('AgLogger', () => {
      */
     describe('Log Methods', () => {
       it('should call all log level methods correctly', () => {
-        const logger = AgLogger.getLogger(mockLogger, mockFormatter);
+        const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
         logger.setLogLevel(AG_LOGLEVEL.TRACE);
 
         logger.fatal('fatal message');
@@ -158,7 +158,7 @@ describe('AgLogger', () => {
       });
 
       it('should handle multiple arguments in log methods', () => {
-        const logger = AgLogger.getLogger(mockLogger, mockFormatter);
+        const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
         logger.setLogLevel(AG_LOGLEVEL.INFO);
 
         const testObj = { key: 'value' };
@@ -176,7 +176,7 @@ describe('AgLogger', () => {
      */
     describe('getLogger Function', () => {
       it('should auto-assign ConsoleLoggerMap when using ConsoleLogger', () => {
-        const logger = getLogger(ConsoleLogger);
+        const logger = getLogger({ defaultLogger: ConsoleLogger });
         logger.setLogLevel(AG_LOGLEVEL.INFO);
 
         // ConsoleLoggerMapが自動適用されることを間接的に確認
@@ -184,7 +184,7 @@ describe('AgLogger', () => {
       });
 
       it('should work with custom logger and formatter', () => {
-        const logger = getLogger(mockLogger, mockFormatter);
+        const logger = getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
         logger.setLogLevel(AG_LOGLEVEL.INFO);
         logger.info('test');
 
@@ -215,7 +215,7 @@ describe('AgLogger', () => {
     });
 
     it('should control verbose output correctly', () => {
-      const logger = AgLogger.getLogger(mockLogger, mockFormatter);
+      const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // verbose off - no output
@@ -230,7 +230,7 @@ describe('AgLogger', () => {
     });
 
     it('should not affect other log levels', () => {
-      const logger = AgLogger.getLogger(mockLogger, mockFormatter);
+      const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.setLogLevel(AG_LOGLEVEL.TRACE);
       logger.setVerbose(false);
 
@@ -252,7 +252,7 @@ describe('AgLogger', () => {
       const throwingLogger = vi.fn(() => {
         throw new Error('Logger error');
       });
-      const logger = AgLogger.getLogger(throwingLogger, mockFormatter);
+      const logger = AgLogger.getLogger({ defaultLogger: throwingLogger, formatter: mockFormatter });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       expect(() => logger.info('test')).toThrow('Logger error');
@@ -262,7 +262,7 @@ describe('AgLogger', () => {
       const throwingFormatter = vi.fn(() => {
         throw new Error('Formatter error');
       });
-      const logger = AgLogger.getLogger(mockLogger, throwingFormatter);
+      const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: throwingFormatter });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       expect(() => logger.info('test')).toThrow('Formatter error');
@@ -270,7 +270,7 @@ describe('AgLogger', () => {
 
     it('should not log when formatter returns empty string', () => {
       const emptyFormatter = vi.fn().mockReturnValue('');
-      const logger = AgLogger.getLogger(mockLogger, emptyFormatter);
+      const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: emptyFormatter });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       logger.info('test message');
@@ -287,7 +287,7 @@ describe('AgLogger', () => {
    */
   describe('エッジケース: Edge Cases', () => {
     it('should handle undefined and null arguments', () => {
-      const logger = AgLogger.getLogger(mockLogger, mockFormatter);
+      const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       logger.info(undefined);
@@ -298,7 +298,7 @@ describe('AgLogger', () => {
     });
 
     it('should handle empty arguments', () => {
-      const logger = AgLogger.getLogger(mockLogger, mockFormatter);
+      const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       logger.info();
@@ -309,7 +309,7 @@ describe('AgLogger', () => {
     });
 
     it('should handle boundary log levels correctly', () => {
-      const logger = AgLogger.getLogger(mockLogger, mockFormatter);
+      const logger = AgLogger.getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
 
       // 最低レベル (FATAL only)
       logger.setLogLevel(AG_LOGLEVEL.FATAL);
@@ -340,7 +340,7 @@ describe('AgLogger', () => {
 
     it('should handle ConsoleLogger auto-configuration', () => {
       // getLogger with ConsoleLogger should auto-assign ConsoleLoggerMap
-      const logger1 = getLogger(ConsoleLogger);
+      const logger1 = getLogger({ defaultLogger: ConsoleLogger });
       expect(logger1).toBeInstanceOf(AgLogger);
 
       // setManager with ConsoleLogger should auto-assign ConsoleLoggerMap

--- a/packages/@agla-utils/ag-logger/src/__tests__/AgLoggerManager.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/AgLoggerManager.spec.ts
@@ -102,7 +102,7 @@ describe('AgLoggerManager', () => {
     });
 
     it('accepts default logger when getting instance', () => {
-      const manager = AgLoggerManager.getManager(mockDefaultLogger);
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
 
       const infoLogger = manager.getLogger(AG_LOGLEVEL.INFO);
       infoLogger('test message');
@@ -111,7 +111,7 @@ describe('AgLoggerManager', () => {
     });
 
     it('accepts formatter when getting instance', () => {
-      const manager = AgLoggerManager.getManager(undefined, mockFormatter);
+      const manager = AgLoggerManager.getManager({ formatter: mockFormatter });
 
       const formatter = manager.getFormatter();
       expect(formatter).toBe(mockFormatter);
@@ -123,7 +123,7 @@ describe('AgLoggerManager', () => {
         [AG_LOGLEVEL.WARN]: mockWarnLogger,
       };
 
-      const manager = AgLoggerManager.getManager(mockDefaultLogger, undefined, loggerMap);
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger, loggerMap: loggerMap });
 
       const errorLogger = manager.getLogger(AG_LOGLEVEL.ERROR);
       const warnLogger = manager.getLogger(AG_LOGLEVEL.WARN);
@@ -144,7 +144,11 @@ describe('AgLoggerManager', () => {
         [AG_LOGLEVEL.ERROR]: mockErrorLogger,
       };
 
-      const manager = AgLoggerManager.getManager(mockDefaultLogger, mockFormatter, loggerMap);
+      const manager = AgLoggerManager.getManager({
+        defaultLogger: mockDefaultLogger,
+        formatter: mockFormatter,
+        loggerMap: loggerMap,
+      });
 
       expect(manager.getFormatter()).toBe(mockFormatter);
 
@@ -176,7 +180,7 @@ describe('AgLoggerManager', () => {
    */
   describe('getLogger', () => {
     it('returns logger function for specified log level', () => {
-      const manager = AgLoggerManager.getManager(mockDefaultLogger);
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
 
       const logger = manager.getLogger(AG_LOGLEVEL.INFO);
       expect(typeof logger).toBe('function');
@@ -186,7 +190,7 @@ describe('AgLoggerManager', () => {
     });
 
     it('returns default logger if log level does not exist', () => {
-      const manager = AgLoggerManager.getManager(mockDefaultLogger);
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
 
       const logger = manager.getLogger(999 as AgTLogLevel);
       expect(logger).toBe(mockDefaultLogger);
@@ -207,7 +211,7 @@ describe('AgLoggerManager', () => {
    */
   describe('getFormatter', () => {
     it('returns the configured formatter', () => {
-      const manager = AgLoggerManager.getManager(undefined, mockFormatter);
+      const manager = AgLoggerManager.getManager({ formatter: mockFormatter });
 
       const formatter = manager.getFormatter();
       expect(formatter).toBe(mockFormatter);
@@ -246,7 +250,7 @@ describe('AgLoggerManager', () => {
     });
 
     it('sets default logger if null is specified', () => {
-      const manager = AgLoggerManager.getManager(mockDefaultLogger);
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
 
       manager.setManager(AG_LOGLEVEL.ERROR, null);
 
@@ -382,7 +386,7 @@ describe('AgLoggerManager', () => {
    */
   describe('Complex scenarios', () => {
     it('can update settings after getLogger', () => {
-      const manager = AgLoggerManager.getManager(mockDefaultLogger);
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
 
       manager.setManager(AG_LOGLEVEL.ERROR, mockErrorLogger);
       manager.setManager({ formatter: mockFormatter });

--- a/packages/@agla-utils/ag-logger/src/__tests__/AgLoggerManager.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/AgLoggerManager.spec.ts
@@ -226,38 +226,33 @@ describe('AgLoggerManager', () => {
   });
 
   /**
-   * setManagerメソッド（legacy形式）のテストスイート
+   * setManagerメソッド（options形式のみ）のテストスイート
    *
-   * @description レガシー形式でのロガー設定機能を検証する
-   * ログレベル指定でのロガー設定、null指定でのデフォルト設定を確認
-   *
-   * @testFocus Legacy Logger Setting
-   * @scenarios
-   * - 指定ログレベルへのロガー設定
-   * - null指定でのデフォルトロガー設定
-   * - 設定後のロガー取得・実行
+   * @description options形式でのロガー設定機能を検証する
+   * legacy形式は削除されsetLogFunctionWithLevelに分離されたことを確認
    */
-  describe('setManager - legacy form', () => {
-    it('sets logger for specified log level', () => {
+  describe('setManager - options only', () => {
+    it('should only accept options object, not legacy form', () => {
       const manager = AgLoggerManager.getManager();
 
-      manager.setManager(AG_LOGLEVEL.ERROR, mockErrorLogger);
-
-      const errorLogger = manager.getLogger(AG_LOGLEVEL.ERROR);
-      errorLogger('error message');
-
-      expect(mockErrorLogger).toHaveBeenCalledWith('error message');
+      // Runtime: setManager now only accepts options object
+      expect(typeof manager.setManager).toBe('function');
     });
 
-    it('sets default logger if null is specified', () => {
-      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
+    it('updates options correctly', () => {
+      const manager = AgLoggerManager.getManager();
 
-      manager.setManager(AG_LOGLEVEL.ERROR, null);
+      manager.setManager({
+        defaultLogger: mockDefaultLogger,
+        formatter: mockFormatter,
+      });
 
-      const errorLogger = manager.getLogger(AG_LOGLEVEL.ERROR);
-      errorLogger('error message');
+      expect(manager.getFormatter()).toBe(mockFormatter);
 
-      expect(mockDefaultLogger).toHaveBeenCalledWith('error message');
+      const infoLogger = manager.getLogger(AG_LOGLEVEL.INFO);
+      infoLogger('info message');
+
+      expect(mockDefaultLogger).toHaveBeenCalledWith('info message');
     });
   });
 
@@ -375,20 +370,19 @@ describe('AgLoggerManager', () => {
    * 複合シナリオのテストスイート
    *
    * @description 実用的な複合設定シナリオを検証する
-   * インスタンス作成後の設定更新、複数setManager呼び出しの動作を確認
+   * setManager（options）とsetLogFunctionWithLevelの組み合わせ動作を確認
    *
    * @testFocus Complex Configuration Scenarios
    * @scenarios
    * - getLogger後の設定更新
-   * - 複数setManager呼び出しの組み合わせ
-   * - legacy形式とoptions形式の混在使用
+   * - setManagerとsetLogFunctionWithLevelの組み合わせ
    * - 設定変更の累積効果
    */
   describe('Complex scenarios', () => {
     it('can update settings after getLogger', () => {
       const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
 
-      manager.setManager(AG_LOGLEVEL.ERROR, mockErrorLogger);
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.ERROR, mockErrorLogger);
       manager.setManager({ formatter: mockFormatter });
 
       expect(manager.getFormatter()).toBe(mockFormatter);
@@ -403,15 +397,15 @@ describe('AgLoggerManager', () => {
       expect(mockDefaultLogger).toHaveBeenCalledWith('info message');
     });
 
-    it('can call setManager multiple times without issue', () => {
+    it('can combine setManager and setLogFunctionWithLevel calls', () => {
       const manager = AgLoggerManager.getManager();
 
       manager.setManager({ defaultLogger: mockDefaultLogger });
-      manager.setManager(AG_LOGLEVEL.ERROR, mockErrorLogger);
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.ERROR, mockErrorLogger);
       manager.setManager({ formatter: mockFormatter });
 
       const secondMockLogger = vi.fn();
-      manager.setManager(AG_LOGLEVEL.WARN, secondMockLogger);
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.WARN, secondMockLogger);
 
       const errorLogger = manager.getLogger(AG_LOGLEVEL.ERROR);
       const warnLogger = manager.getLogger(AG_LOGLEVEL.WARN);
@@ -425,6 +419,124 @@ describe('AgLoggerManager', () => {
       expect(secondMockLogger).toHaveBeenCalledWith('warn message');
       expect(mockDefaultLogger).toHaveBeenCalledWith('info message');
       expect(manager.getFormatter()).toBe(mockFormatter);
+    });
+  });
+
+  /**
+   * setLogFunctionWithLevelメソッドのテストスイート
+   *
+   * @description 個別ログレベルへの特定ロガー関数設定機能を検証する
+   * 指定レベルへのロガー設定、他レベルへの影響なしを確認
+   *
+   * @testFocus Specific Logger Function Setting
+   * @scenarios
+   * - 指定ログレベルへの特定ロガー関数設定
+   * - 他ログレベルに影響しないこと
+   * - 複数レベルへの個別設定
+   */
+  describe('setLogFunctionWithLevel', () => {
+    it('sets specific logger function for specified log level', () => {
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
+
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.ERROR, mockErrorLogger);
+
+      const errorLogger = manager.getLogger(AG_LOGLEVEL.ERROR);
+      errorLogger('error message');
+
+      expect(mockErrorLogger).toHaveBeenCalledWith('error message');
+    });
+
+    it('does not affect other log levels', () => {
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
+
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.ERROR, mockErrorLogger);
+
+      const errorLogger = manager.getLogger(AG_LOGLEVEL.ERROR);
+      const warnLogger = manager.getLogger(AG_LOGLEVEL.WARN);
+      const infoLogger = manager.getLogger(AG_LOGLEVEL.INFO);
+
+      errorLogger('error message');
+      warnLogger('warn message');
+      infoLogger('info message');
+
+      expect(mockErrorLogger).toHaveBeenCalledWith('error message');
+      expect(mockDefaultLogger).toHaveBeenCalledWith('warn message');
+      expect(mockDefaultLogger).toHaveBeenCalledWith('info message');
+    });
+
+    it('allows setting different functions for multiple levels', () => {
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
+
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.ERROR, mockErrorLogger);
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.WARN, mockWarnLogger);
+
+      const errorLogger = manager.getLogger(AG_LOGLEVEL.ERROR);
+      const warnLogger = manager.getLogger(AG_LOGLEVEL.WARN);
+      const infoLogger = manager.getLogger(AG_LOGLEVEL.INFO);
+
+      errorLogger('error message');
+      warnLogger('warn message');
+      infoLogger('info message');
+
+      expect(mockErrorLogger).toHaveBeenCalledWith('error message');
+      expect(mockWarnLogger).toHaveBeenCalledWith('warn message');
+      expect(mockDefaultLogger).toHaveBeenCalledWith('info message');
+    });
+  });
+
+  /**
+   * setDefaultLogFunctionメソッドのテストスイート
+   *
+   * @description 個別ログレベルのデフォルトロガー設定機能を検証する
+   * 特定レベルをデフォルトロガーに戻す機能を確認
+   *
+   * @testFocus Default Logger Function Setting
+   * @scenarios
+   * - 指定ログレベルをデフォルトロガーに設定
+   * - 既存の特定ロガーからデフォルトロガーへの変更
+   * - 他レベルに影響しないこと
+   */
+  describe('setDefaultLogFunction', () => {
+    it('sets log level to use default logger', () => {
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
+
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.ERROR, mockErrorLogger);
+      manager.setDefaultLogFunction(AG_LOGLEVEL.ERROR);
+
+      const errorLogger = manager.getLogger(AG_LOGLEVEL.ERROR);
+      errorLogger('error message');
+
+      expect(mockDefaultLogger).toHaveBeenCalledWith('error message');
+      expect(mockErrorLogger).not.toHaveBeenCalled();
+    });
+
+    it('does not affect other log levels', () => {
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
+
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.ERROR, mockErrorLogger);
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.WARN, mockWarnLogger);
+      manager.setDefaultLogFunction(AG_LOGLEVEL.ERROR);
+
+      const errorLogger = manager.getLogger(AG_LOGLEVEL.ERROR);
+      const warnLogger = manager.getLogger(AG_LOGLEVEL.WARN);
+
+      errorLogger('error message');
+      warnLogger('warn message');
+
+      expect(mockDefaultLogger).toHaveBeenCalledWith('error message');
+      expect(mockWarnLogger).toHaveBeenCalledWith('warn message');
+      expect(mockErrorLogger).not.toHaveBeenCalled();
+    });
+
+    it('works even when no custom logger was previously set', () => {
+      const manager = AgLoggerManager.getManager({ defaultLogger: mockDefaultLogger });
+
+      manager.setDefaultLogFunction(AG_LOGLEVEL.INFO);
+
+      const infoLogger = manager.getLogger(AG_LOGLEVEL.INFO);
+      infoLogger('info message');
+
+      expect(mockDefaultLogger).toHaveBeenCalledWith('info message');
     });
   });
 });

--- a/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.json.e2e.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.json.e2e.spec.ts
@@ -70,7 +70,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
     describe('Basic JSON Output', () => {
       it('should output structured JSON logs for all levels', () => {
         setupTestContext();
-        const logger = getLogger(ConsoleLogger, JsonFormat);
+        const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
         logger.setLogLevel(AG_LOGLEVEL.TRACE);
 
         const testCases = [
@@ -107,7 +107,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
     describe('Multiple Arguments Processing', () => {
       it('should handle complex data structures in JSON format', () => {
         setupTestContext();
-        const logger = getLogger(ConsoleLogger, JsonFormat);
+        const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
         logger.setLogLevel(AG_LOGLEVEL.INFO);
 
         const complexData = {
@@ -132,7 +132,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
 
       it('should handle arrays and primitive types correctly', () => {
         setupTestContext();
-        const logger = getLogger(ConsoleLogger, JsonFormat);
+        const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
         logger.setLogLevel(AG_LOGLEVEL.DEBUG);
 
         const testData = {
@@ -163,7 +163,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
     describe('JSON Format Specific Features', () => {
       it('should omit args property when no structured arguments', () => {
         setupTestContext();
-        const logger = getLogger(ConsoleLogger, JsonFormat);
+        const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
         logger.setLogLevel(AG_LOGLEVEL.INFO);
 
         logger.info('Simple message without args');
@@ -182,7 +182,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
 
       it('should maintain JSON structure with empty objects and arrays', () => {
         setupTestContext();
-        const logger = getLogger(ConsoleLogger, JsonFormat);
+        const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
         logger.setLogLevel(AG_LOGLEVEL.WARN);
 
         logger.warn('Empty structures test', {}, [], '');
@@ -208,7 +208,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
   describe('Log Level Filtering', () => {
     it('should filter logs based on current level with JSON output', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
 
       // INFO レベルに設定
       logger.setLogLevel(AG_LOGLEVEL.INFO);
@@ -230,7 +230,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
 
     it('should block all output when level is OFF', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.OFF);
 
       logger.fatal('fatal message');
@@ -252,7 +252,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
   describe('異常系: Error Handling', () => {
     it('should handle JSON serialization errors gracefully', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.ERROR);
 
       // 循環参照オブジェクト
@@ -273,7 +273,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
   describe('エッジケース: Real-world Scenarios', () => {
     it('should handle complete application lifecycle logging', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.DEBUG);
 
       // アプリケーション起動
@@ -339,7 +339,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
 
     it('should handle high-frequency logging with JSON format', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // 大量のログ出力をシミュレート
@@ -370,7 +370,7 @@ describe('AgLogger E2E Tests - JSON Format with Console Logger', () => {
 
     it('should handle log method (generic) with JSON format', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       logger.log('Generic log message', { data: 'test' });

--- a/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.json.e2e.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.json.e2e.spec.ts
@@ -12,7 +12,7 @@ import { describe, expect, it, vi } from 'vitest';
 // ログレベル定数 - E2Eテストで使用するログレベル定義
 import { AG_LOGLEVEL } from '../../shared/types';
 // テスト対象 - getLogger関数（ロガー取得のエントリーポイント）
-import { getLogger } from '../../src/AgLogger.class';
+import { getLogger } from '@/AgLogger.class';
 
 // --- types ---
 import type { AG_LABEL_TO_LOGLEVEL_MAP } from '../../shared/types';
@@ -24,9 +24,9 @@ type TMockConsoleMethods = keyof typeof mockConsole;
 type TCircularObject = { name: string; self?: TCircularObject };
 
 // プラグイン - JSON形式フォーマッター（構造化ログ用）
-import { JsonFormat } from '../../src/plugins/format/JsonFormat';
+import { JsonFormat } from '@/plugins/format/JsonFormat';
 // プラグイン - コンソール出力ロガー
-import { ConsoleLogger } from '../../src/plugins/logger/ConsoleLogger';
+import { ConsoleLogger } from '@/plugins/logger/ConsoleLogger';
 
 // mock console methods
 const mockConsole = {

--- a/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.parameterOmission.e2e.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.parameterOmission.e2e.spec.ts
@@ -12,11 +12,11 @@ import { describe, expect, it, vi } from 'vitest';
 // ログレベル定数 - E2Eテストで使用するログレベル定義
 import { AG_LOGLEVEL } from '../../shared/types';
 // テスト対象 - getLogger関数（ロガー取得のエントリーポイント）
-import { getLogger } from '../../src/AgLogger.class';
+import { getLogger } from '@/AgLogger.class';
 // プラグイン - 人間可読な平文フォーマッター
-import { PlainFormat } from '../../src/plugins/format/PlainFormat';
+import { PlainFormat } from '@/plugins/format/PlainFormat';
 // プラグイン - コンソール出力ロガー
-import { ConsoleLogger } from '../../src/plugins/logger/ConsoleLogger';
+import { ConsoleLogger } from '@/plugins/logger/ConsoleLogger';
 
 // mock console methods
 const mockConsole = {

--- a/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.parameterOmission.e2e.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.parameterOmission.e2e.spec.ts
@@ -65,7 +65,7 @@ describe('AgLogger E2E Tests - Parameter Omission and setManager', () => {
     it('uses previous settings when all parameters are omitted after initial setup', () => {
       setupTestContext();
       // Initial setup
-      const logger1 = getLogger(ConsoleLogger, PlainFormat);
+      const logger1 = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger1.setLogLevel(AG_LOGLEVEL.INFO);
       logger1.info('Log after initial setup');
 
@@ -85,10 +85,10 @@ describe('AgLogger E2E Tests - Parameter Omission and setManager', () => {
     it('uses previous settings when only partial parameters are omitted', () => {
       setupTestContext();
       // Initial setup
-      getLogger(ConsoleLogger, PlainFormat);
+      getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
 
       // Omit formatter only
-      const logger = getLogger(ConsoleLogger);
+      const logger = getLogger({ defaultLogger: ConsoleLogger });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
       logger.info('Log after partial parameter omission');
 
@@ -99,9 +99,9 @@ describe('AgLogger E2E Tests - Parameter Omission and setManager', () => {
 
     it('ensures singleton behavior', () => {
       setupTestContext();
-      const logger1 = getLogger(ConsoleLogger, PlainFormat);
+      const logger1 = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       const logger2 = getLogger();
-      const logger3 = getLogger(ConsoleLogger);
+      const logger3 = getLogger({ defaultLogger: ConsoleLogger });
 
       expect(logger1).toBe(logger2);
       expect(logger2).toBe(logger3);
@@ -123,7 +123,7 @@ describe('AgLogger E2E Tests - Parameter Omission and setManager', () => {
   describe('setManager method functionality', () => {
     it('updates all settings at once via setManager', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // Change settings via setManager
@@ -141,7 +141,7 @@ describe('AgLogger E2E Tests - Parameter Omission and setManager', () => {
 
     it('updates partial settings via setManager', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // Change only formatter
@@ -158,7 +158,7 @@ describe('AgLogger E2E Tests - Parameter Omission and setManager', () => {
 
     it('updates only defaultLogger via setManager', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // Change only defaultLogger
@@ -192,7 +192,7 @@ describe('AgLogger E2E Tests - Parameter Omission and setManager', () => {
     it('combines setting changes and parameter omission', () => {
       setupTestContext();
       // Initial setup
-      const logger1 = getLogger(ConsoleLogger, PlainFormat);
+      const logger1 = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger1.setLogLevel(AG_LOGLEVEL.INFO);
       logger1.info('Initial setup');
 
@@ -219,7 +219,7 @@ describe('AgLogger E2E Tests - Parameter Omission and setManager', () => {
 
     it('overwrites settings via multiple setManager calls', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // First settings update

--- a/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.plain.e2e.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.plain.e2e.spec.ts
@@ -65,7 +65,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
   describe('Basic log output tests', () => {
     it('outputs INFO log using PlainFormat and ConsoleLogger', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       logger.info('Test message');
@@ -77,7 +77,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
 
     it('outputs ERROR log using PlainFormat and ConsoleLogger', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.ERROR);
 
       logger.error('Error message');
@@ -89,7 +89,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
 
     it('outputs WARN log using PlainFormat and ConsoleLogger', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.WARN);
 
       logger.warn('Warning message');
@@ -101,7 +101,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
 
     it('outputs DEBUG log using PlainFormat and ConsoleLogger', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.DEBUG);
 
       logger.debug('Debug message');
@@ -129,7 +129,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
   describe('Log output tests with multiple arguments', () => {
     it('logs message containing object and string', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       const userData = { userId: 123, userName: 'testUser' };
@@ -144,7 +144,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
 
     it('logs message containing an array', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.DEBUG);
 
       const items = ['item1', 'item2', 'item3'];
@@ -175,7 +175,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
   describe('Log level filtering tests', () => {
     it('does not output DEBUG logs when level is INFO', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       logger.debug('Debug message');
@@ -187,7 +187,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
 
     it('does not output INFO/WARN logs when level is ERROR', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.ERROR);
 
       logger.info('Info message');
@@ -201,7 +201,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
 
     it('does not output any logs when level is OFF', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.OFF);
 
       logger.error('Error message');
@@ -228,7 +228,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
   describe('Error handling tests', () => {
     it('throws error when logging circular reference objects', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       const circularObj: { name: string; self?: unknown } = { name: 'test' };
@@ -257,7 +257,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
   describe('Full integration scenario tests', () => {
     it('logs a sequence from app start to error occurrence', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.DEBUG);
 
       // Application start
@@ -297,7 +297,7 @@ describe('AgLogger E2E Tests - Plain Format with Console Logger', () => {
 
     it('verifies log method (log) functionality', () => {
       setupTestContext();
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       logger.log('General log message');

--- a/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.plain.e2e.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/e2e/AgLogger.plain.e2e.spec.ts
@@ -12,11 +12,11 @@ import { describe, expect, it, vi } from 'vitest';
 // ログレベル定数 - E2Eテストで使用するログレベル定義
 import { AG_LOGLEVEL } from '../../shared/types';
 // テスト対象 - getLogger関数（ロガー取得のエントリーポイント）
-import { getLogger } from '../../src/AgLogger.class';
+import { getLogger } from '@/AgLogger.class';
 // プラグイン - 人間可読な平文フォーマッター
-import { PlainFormat } from '../../src/plugins/format/PlainFormat';
+import { PlainFormat } from '@/plugins/format/PlainFormat';
 // プラグイン - コンソール出力ロガー
-import { ConsoleLogger } from '../../src/plugins/logger/ConsoleLogger';
+import { ConsoleLogger } from '@/plugins/logger/ConsoleLogger';
 
 // mock console methods
 const mockConsole = {

--- a/packages/@agla-utils/ag-logger/tests/e2e/E2EMockLogger.e2e.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/e2e/E2EMockLogger.e2e.spec.ts
@@ -6,11 +6,11 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+import { getLogger } from '@/AgLogger.class';
+import { PlainFormat } from '@/plugins/format/PlainFormat';
 import { E2eMockLogger as E2EMockLoggerWithTestId } from '@/plugins/logger/E2eMockLogger';
 import { describe, expect, it } from 'vitest';
 import { AG_LOGLEVEL } from '../../shared/types';
-import { getLogger } from '../../src/AgLogger.class';
-import { PlainFormat } from '../../src/plugins/format/PlainFormat';
 
 describe('E2EMockLoggerWithTestId', () => {
   describe('Basic logging functionality', () => {

--- a/packages/@agla-utils/ag-logger/tests/e2e/E2EMockLogger.e2e.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/e2e/E2EMockLogger.e2e.spec.ts
@@ -96,7 +96,7 @@ describe('E2EMockLoggerWithTestId', () => {
       ctx.onTestFinished(() => mockLogger.endTest());
 
       const loggerFunction = mockLogger.createLoggerFunction();
-      const logger = getLogger(loggerFunction, PlainFormat);
+      const logger = getLogger({ defaultLogger: loggerFunction, formatter: PlainFormat });
 
       logger.setLogLevel(AG_LOGLEVEL.INFO);
       logger.info('Test message via plugin');
@@ -111,7 +111,11 @@ describe('E2EMockLoggerWithTestId', () => {
       ctx.onTestFinished(() => mockLogger.endTest());
 
       const loggerMap = mockLogger.createLoggerMap();
-      const logger = getLogger(mockLogger.createLoggerFunction(), PlainFormat, loggerMap);
+      const logger = getLogger({
+        defaultLogger: mockLogger.createLoggerFunction(),
+        formatter: PlainFormat,
+        loggerMap: loggerMap,
+      });
 
       logger.setLogLevel(AG_LOGLEVEL.DEBUG);
       logger.error('Error message');

--- a/packages/@agla-utils/ag-logger/tests/integration/AgLogger.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/AgLogger.integration.spec.ts
@@ -15,15 +15,15 @@ import { AG_LOGLEVEL } from '../../shared/types';
 // Type definitions for vitest mocks
 type TVitestMock = ReturnType<typeof vi.fn>;
 // テスト対象 - メインAgLoggerクラスとgetLogger関数
-import { AgLogger, getLogger } from '../../src/AgLogger.class';
+import { AgLogger, getLogger } from '@/AgLogger.class';
 // テスト対象 - ロガー・フォーマッター管理クラス
-import { AgLoggerManager } from '../../src/AgLoggerManager.class';
+import { AgLoggerManager } from '@/AgLoggerManager.class';
 // フォーマッタープラグイン
-import { JsonFormat } from '../../src/plugins/format/JsonFormat';
-import { NullFormat } from '../../src/plugins/format/NullFormat';
-import { PlainFormat } from '../../src/plugins/format/PlainFormat';
+import { JsonFormat } from '@/plugins/format/JsonFormat';
+import { NullFormat } from '@/plugins/format/NullFormat';
+import { PlainFormat } from '@/plugins/format/PlainFormat';
 // ロガープラグイン
-import { ConsoleLogger } from '../../src/plugins/logger/ConsoleLogger';
+import { ConsoleLogger } from '@/plugins/logger/ConsoleLogger';
 
 /**
  * AgLoggerコンポーネントの包括的統合テストスイート

--- a/packages/@agla-utils/ag-logger/tests/integration/AgLogger.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/AgLogger.integration.spec.ts
@@ -136,7 +136,7 @@ describe('AgLogger Integration Tests', () => {
 
         testCases.forEach(({ logger, formatter, setupSpy, verify }) => {
           const spy = setupSpy();
-          const testLogger = getLogger(logger, formatter);
+          const testLogger = getLogger({ defaultLogger: logger, formatter: formatter });
           testLogger.setLogLevel(AG_LOGLEVEL.INFO);
           testLogger.info('test message', { data: 'test' });
 
@@ -151,7 +151,7 @@ describe('AgLogger Integration Tests', () => {
 
         // NullFormat + 任意のロガー = 出力なし
         const mockLogger = vi.fn();
-        const logger = getLogger(mockLogger, NullFormat);
+        const logger = getLogger({ defaultLogger: mockLogger, formatter: NullFormat });
         logger.setLogLevel(AG_LOGLEVEL.INFO);
         logger.info('test message');
 
@@ -172,9 +172,13 @@ describe('AgLogger Integration Tests', () => {
         const warnLogger = vi.fn();
         const defaultLogger = vi.fn();
 
-        const logger = getLogger(defaultLogger, PlainFormat, {
-          [AG_LOGLEVEL.ERROR]: errorLogger,
-          [AG_LOGLEVEL.WARN]: warnLogger,
+        const logger = getLogger({
+          defaultLogger: defaultLogger,
+          formatter: PlainFormat,
+          loggerMap: {
+            [AG_LOGLEVEL.ERROR]: errorLogger,
+            [AG_LOGLEVEL.WARN]: warnLogger,
+          },
         });
 
         logger.setLogLevel(AG_LOGLEVEL.DEBUG);
@@ -234,7 +238,11 @@ describe('AgLogger Integration Tests', () => {
           [AG_LOGLEVEL.DEBUG]: vi.fn(),
         };
 
-        const logger = getLogger(loggers[AG_LOGLEVEL.INFO], JsonFormat, loggers);
+        const logger = getLogger({
+          defaultLogger: loggers[AG_LOGLEVEL.INFO],
+          formatter: JsonFormat,
+          loggerMap: loggers,
+        });
         logger.setLogLevel(AG_LOGLEVEL.WARN);
 
         // フィルタリングテスト
@@ -255,7 +263,7 @@ describe('AgLogger Integration Tests', () => {
         const mockLogger = vi.fn();
         const mockFormatter = vi.fn();
 
-        const logger = getLogger(mockLogger, mockFormatter);
+        const logger = getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
         logger.setLogLevel(AG_LOGLEVEL.OFF);
 
         // 全レベルでフィルタリング
@@ -284,7 +292,7 @@ describe('AgLogger Integration Tests', () => {
         const mockLogger = vi.fn();
         const mockFormatter = vi.fn().mockReturnValue('verbose formatted');
 
-        const logger = getLogger(mockLogger, mockFormatter);
+        const logger = getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
         logger.setLogLevel(AG_LOGLEVEL.INFO);
 
         // verbose無効時
@@ -329,7 +337,7 @@ describe('AgLogger Integration Tests', () => {
         throw new Error('Logger error');
       });
 
-      const logger = getLogger(throwingLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: throwingLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       expect(() => logger.info('test')).toThrow('Logger error');
@@ -350,7 +358,7 @@ describe('AgLogger Integration Tests', () => {
         throw new Error('Formatter error');
       });
 
-      const logger = getLogger(mockLogger, throwingFormatter);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: throwingFormatter });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       expect(() => logger.info('test')).toThrow('Formatter error');
@@ -364,8 +372,12 @@ describe('AgLogger Integration Tests', () => {
         throw new Error('Error logger failed');
       });
 
-      const logger = getLogger(mockLogger, PlainFormat, {
-        [AG_LOGLEVEL.ERROR]: errorLogger,
+      const logger = getLogger({
+        defaultLogger: mockLogger,
+        formatter: PlainFormat,
+        loggerMap: {
+          [AG_LOGLEVEL.ERROR]: errorLogger,
+        },
       });
 
       logger.setLogLevel(AG_LOGLEVEL.DEBUG);
@@ -414,7 +426,7 @@ describe('AgLogger Integration Tests', () => {
       setupTestContext();
 
       const mockLogger = vi.fn();
-      const logger = getLogger(mockLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // 同時実行パターンのシミュレーション
@@ -437,7 +449,7 @@ describe('AgLogger Integration Tests', () => {
       setupTestContext();
 
       const mockLogger = vi.fn();
-      const logger = getLogger(mockLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // 大量のログ出力
@@ -458,7 +470,7 @@ describe('AgLogger Integration Tests', () => {
       const mockLogger = vi.fn();
       const mockFormatter = vi.fn().mockReturnValue('formatted null/undefined');
 
-      const logger = getLogger(mockLogger, mockFormatter);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       const testCases = [

--- a/packages/@agla-utils/ag-logger/tests/integration/AgLoggerManager.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/AgLoggerManager.integration.spec.ts
@@ -13,12 +13,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { AG_LOGLEVEL } from '../../shared/types';
 import type { AgTLogLevel } from '../../shared/types';
 // test targets
-import { AgLoggerManager } from '../../src/AgLoggerManager.class';
-import { JsonFormat } from '../../src/plugins/format/JsonFormat';
-import { NullFormat } from '../../src/plugins/format/NullFormat';
-import { PlainFormat } from '../../src/plugins/format/PlainFormat';
-import { ConsoleLogger } from '../../src/plugins/logger/ConsoleLogger';
-import { NullLogger } from '../../src/plugins/logger/NullLogger';
+import { AgLoggerManager } from '@/AgLoggerManager.class';
+import { JsonFormat } from '@/plugins/format/JsonFormat';
+import { NullFormat } from '@/plugins/format/NullFormat';
+import { PlainFormat } from '@/plugins/format/PlainFormat';
+import { ConsoleLogger } from '@/plugins/logger/ConsoleLogger';
+import { NullLogger } from '@/plugins/logger/NullLogger';
 
 /**
  * Integration tests for AgLoggerManager.

--- a/packages/@agla-utils/ag-logger/tests/integration/AgLoggerManager.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/AgLoggerManager.integration.spec.ts
@@ -256,14 +256,14 @@ describe('AgLoggerManager Integration Tests', () => {
       const manager = AgLoggerManager.getManager();
       const customLogger = vi.fn();
 
-      // Test legacy single-level logger setting
-      manager.setManager(AG_LOGLEVEL.ERROR, customLogger);
+      // Test single-level logger setting with setLogFunctionWithLevel
+      manager.setLogFunctionWithLevel(AG_LOGLEVEL.ERROR, customLogger);
       expect(manager.getLogger(AG_LOGLEVEL.ERROR)).toBe(customLogger);
 
-      // Test legacy null logger setting (should use default)
+      // Test setting default logger for a level
       const defaultLogger = vi.fn();
       manager.setManager({ defaultLogger });
-      manager.setManager(AG_LOGLEVEL.INFO, null);
+      manager.setDefaultLogFunction(AG_LOGLEVEL.INFO);
       expect(manager.getLogger(AG_LOGLEVEL.INFO)).toBe(defaultLogger);
     });
 

--- a/packages/@agla-utils/ag-logger/tests/integration/AgLoggerManager.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/AgLoggerManager.integration.spec.ts
@@ -43,7 +43,7 @@ describe('AgLoggerManager Integration Tests', () => {
       setupTestContext();
       const manager1 = AgLoggerManager.getManager();
       const manager2 = AgLoggerManager.getManager();
-      const manager3 = AgLoggerManager.getManager(ConsoleLogger, JsonFormat);
+      const manager3 = AgLoggerManager.getManager({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
 
       expect(manager1).toBe(manager2);
       expect(manager2).toBe(manager3);
@@ -54,7 +54,7 @@ describe('AgLoggerManager Integration Tests', () => {
       const mockLogger = vi.fn();
       const mockFormatter = vi.fn().mockReturnValue('test output');
 
-      const manager1 = AgLoggerManager.getManager(mockLogger, mockFormatter);
+      const manager1 = AgLoggerManager.getManager({ defaultLogger: mockLogger, formatter: mockFormatter });
       const manager2 = AgLoggerManager.getManager();
 
       // Both should have the same configuration
@@ -69,8 +69,8 @@ describe('AgLoggerManager Integration Tests', () => {
       const firstFormatter = vi.fn().mockReturnValue('first');
       const secondFormatter = vi.fn().mockReturnValue('second');
 
-      const manager1 = AgLoggerManager.getManager(firstLogger, firstFormatter);
-      const manager2 = AgLoggerManager.getManager(secondLogger, secondFormatter);
+      const manager1 = AgLoggerManager.getManager({ defaultLogger: firstLogger, formatter: firstFormatter });
+      const manager2 = AgLoggerManager.getManager({ defaultLogger: secondLogger, formatter: secondFormatter });
 
       // Second call with parameters should still update configuration
       // since getManager allows configuration updates
@@ -102,7 +102,11 @@ describe('AgLoggerManager Integration Tests', () => {
         [AG_LOGLEVEL.TRACE]: debugLogger,
       };
 
-      const manager = AgLoggerManager.getManager(defaultLogger, PlainFormat, loggerMap);
+      const manager = AgLoggerManager.getManager({
+        defaultLogger: defaultLogger,
+        formatter: PlainFormat,
+        loggerMap: loggerMap,
+      });
 
       expect(manager.getLogger(AG_LOGLEVEL.OFF)).toBe(NullLogger);
       expect(manager.getLogger(AG_LOGLEVEL.FATAL)).toBe(errorLogger);
@@ -124,7 +128,11 @@ describe('AgLoggerManager Integration Tests', () => {
         [AG_LOGLEVEL.DEBUG]: debugLogger,
       };
 
-      const manager = AgLoggerManager.getManager(defaultLogger, PlainFormat, partialLoggerMap);
+      const manager = AgLoggerManager.getManager({
+        defaultLogger: defaultLogger,
+        formatter: PlainFormat,
+        loggerMap: partialLoggerMap,
+      });
 
       // Specified levels should use custom loggers
       expect(manager.getLogger(AG_LOGLEVEL.ERROR)).toBe(errorLogger);
@@ -140,7 +148,7 @@ describe('AgLoggerManager Integration Tests', () => {
     it('should fallback to default logger for missing map entries', () => {
       setupTestContext();
       const defaultLogger = vi.fn();
-      const manager = AgLoggerManager.getManager(defaultLogger, PlainFormat);
+      const manager = AgLoggerManager.getManager({ defaultLogger: defaultLogger, formatter: PlainFormat });
 
       // All levels should return the default logger
       Object.values(AG_LOGLEVEL).forEach((level) => {
@@ -159,7 +167,7 @@ describe('AgLoggerManager Integration Tests', () => {
     it('should maintain formatter consistency across logger retrievals', () => {
       setupTestContext();
       const mockFormatter = vi.fn().mockReturnValue('formatted');
-      const manager = AgLoggerManager.getManager(ConsoleLogger, mockFormatter);
+      const manager = AgLoggerManager.getManager({ defaultLogger: ConsoleLogger, formatter: mockFormatter });
 
       const formatter1 = manager.getFormatter();
       const formatter2 = manager.getFormatter();
@@ -173,7 +181,7 @@ describe('AgLoggerManager Integration Tests', () => {
       const firstFormatter = vi.fn().mockReturnValue('first format');
       const secondFormatter = vi.fn().mockReturnValue('second format');
 
-      const manager = AgLoggerManager.getManager(ConsoleLogger, firstFormatter);
+      const manager = AgLoggerManager.getManager({ defaultLogger: ConsoleLogger, formatter: firstFormatter });
       expect(manager.getFormatter()).toBe(firstFormatter);
 
       manager.setManager({ formatter: secondFormatter });
@@ -316,7 +324,11 @@ describe('AgLoggerManager Integration Tests', () => {
     it('should handle empty logger map correctly', () => {
       setupTestContext();
       const defaultLogger = vi.fn();
-      const manager = AgLoggerManager.getManager(defaultLogger, PlainFormat, {});
+      const manager = AgLoggerManager.getManager({
+        defaultLogger: defaultLogger,
+        formatter: PlainFormat,
+        loggerMap: {},
+      });
 
       // Should use default logger for all levels
       Object.values(AG_LOGLEVEL).forEach((level) => {

--- a/packages/@agla-utils/ag-logger/tests/integration/PluginInteraction.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/PluginInteraction.integration.spec.ts
@@ -12,17 +12,17 @@ import { describe, expect, it, vi } from 'vitest';
 // ログレベル定数 - テストで使用するログレベル定義
 import { AG_LOGLEVEL } from '../../shared/types';
 // テスト対象 - getLogger関数（ロガー取得のエントリーポイント）
-import { getLogger } from '../../src/AgLogger.class';
+import { getLogger } from '@/AgLogger.class';
 // フォーマッタープラグイン - JSON形式でのログフォーマット
-import { JsonFormat } from '../../src/plugins/format/JsonFormat';
+import { JsonFormat } from '@/plugins/format/JsonFormat';
 // フォーマッタープラグイン - 出力なしのダミーフォーマット
-import { NullFormat } from '../../src/plugins/format/NullFormat';
+import { NullFormat } from '@/plugins/format/NullFormat';
 // フォーマッタープラグイン - 人間可読な平文フォーマット
-import { PlainFormat } from '../../src/plugins/format/PlainFormat';
+import { PlainFormat } from '@/plugins/format/PlainFormat';
 // ロガープラグイン - コンソール出力ロガーとレベルマップ
-import { ConsoleLogger, ConsoleLoggerMap } from '../../src/plugins/logger/ConsoleLogger';
+import { ConsoleLogger, ConsoleLoggerMap } from '@/plugins/logger/ConsoleLogger';
 // ロガープラグイン - 出力なしのダミーロガー
-import { NullLogger } from '../../src/plugins/logger/NullLogger';
+import { NullLogger } from '@/plugins/logger/NullLogger';
 
 // types
 type TCircular = {

--- a/packages/@agla-utils/ag-logger/tests/integration/PluginInteraction.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/PluginInteraction.integration.spec.ts
@@ -71,7 +71,7 @@ describe('Plugin Interaction Integration Tests', () => {
       setupTestContext();
       const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
 
-      const logger = getLogger(ConsoleLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
       logger.info('test message', { data: 'value' });
 
@@ -94,7 +94,7 @@ describe('Plugin Interaction Integration Tests', () => {
       setupTestContext();
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      const logger = getLogger(ConsoleLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.WARN);
       logger.warn('warning message', 'additional info');
 
@@ -111,7 +111,7 @@ describe('Plugin Interaction Integration Tests', () => {
       setupTestContext();
       const mockLogger = vi.fn();
 
-      const logger = getLogger(mockLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.DEBUG);
       logger.debug('debug message', { debug: true });
 
@@ -132,7 +132,7 @@ describe('Plugin Interaction Integration Tests', () => {
       setupTestContext();
       const mockLogger = vi.fn();
 
-      const logger = getLogger(mockLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.ERROR);
       logger.error('error message', 'error details');
 
@@ -145,7 +145,7 @@ describe('Plugin Interaction Integration Tests', () => {
 
     it('should handle NullLogger with any formatter correctly', () => {
       setupTestContext();
-      const logger = getLogger(NullLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: NullLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // Should not throw and should complete silently
@@ -158,7 +158,7 @@ describe('Plugin Interaction Integration Tests', () => {
       setupTestContext();
       const mockLogger = vi.fn();
 
-      const logger = getLogger(mockLogger, NullFormat);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: NullFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
       logger.info('test message');
 
@@ -192,7 +192,7 @@ describe('Plugin Interaction Integration Tests', () => {
         log: vi.spyOn(console, 'log').mockImplementation(() => {}),
       };
 
-      const logger = getLogger(ConsoleLogger, JsonFormat, ConsoleLoggerMap);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: JsonFormat, loggerMap: ConsoleLoggerMap });
       logger.setLogLevel(AG_LOGLEVEL.TRACE);
 
       logger.fatal('fatal message');
@@ -230,7 +230,7 @@ describe('Plugin Interaction Integration Tests', () => {
         log: vi.spyOn(console, 'log').mockImplementation(() => {}),
       };
 
-      const logger = getLogger(ConsoleLogger, PlainFormat, ConsoleLoggerMap);
+      const logger = getLogger({ defaultLogger: ConsoleLogger, formatter: PlainFormat, loggerMap: ConsoleLoggerMap });
       logger.setLogLevel(AG_LOGLEVEL.TRACE);
 
       logger.fatal('fatal message');
@@ -296,7 +296,7 @@ describe('Plugin Interaction Integration Tests', () => {
 
       // Test with JsonFormat
       const jsonMockLogger = vi.fn();
-      const jsonLogger = getLogger(jsonMockLogger, JsonFormat);
+      const jsonLogger = getLogger({ defaultLogger: jsonMockLogger, formatter: JsonFormat });
       jsonLogger.setLogLevel(AG_LOGLEVEL.INFO);
       jsonLogger.info('Complex data', complexData);
 
@@ -309,7 +309,7 @@ describe('Plugin Interaction Integration Tests', () => {
 
       // Test with PlainFormat
       const plainMockLogger = vi.fn();
-      const plainLogger = getLogger(plainMockLogger, PlainFormat);
+      const plainLogger = getLogger({ defaultLogger: plainMockLogger, formatter: PlainFormat });
       plainLogger.setLogLevel(AG_LOGLEVEL.INFO);
       plainLogger.info('Complex data', complexData);
 
@@ -328,7 +328,7 @@ describe('Plugin Interaction Integration Tests', () => {
 
       // Test with JsonFormat (should handle circular references)
       const jsonMockLogger = vi.fn();
-      const jsonLogger = getLogger(jsonMockLogger, JsonFormat);
+      const jsonLogger = getLogger({ defaultLogger: jsonMockLogger, formatter: JsonFormat });
       jsonLogger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // JSON.stringify with circular references should throw, so we expect the error to propagate
@@ -338,7 +338,7 @@ describe('Plugin Interaction Integration Tests', () => {
 
       // Test with PlainFormat - also uses JSON.stringify
       const plainMockLogger = vi.fn();
-      const plainLogger = getLogger(plainMockLogger, PlainFormat);
+      const plainLogger = getLogger({ defaultLogger: plainMockLogger, formatter: PlainFormat });
       plainLogger.setLogLevel(AG_LOGLEVEL.INFO);
 
       expect(() => {
@@ -351,7 +351,7 @@ describe('Plugin Interaction Integration Tests', () => {
       const largeArray = Array.from({ length: 1000 }, (_, i) => ({ id: i, data: `item${i}` }));
 
       const mockLogger = vi.fn();
-      const logger = getLogger(mockLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       const startTime = Date.now();
@@ -385,7 +385,7 @@ describe('Plugin Interaction Integration Tests', () => {
     it('should maintain performance with high-frequency logging', () => {
       setupTestContext();
       const mockLogger = vi.fn();
-      const logger = getLogger(mockLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.DEBUG);
 
       const iterations = 1000;
@@ -406,7 +406,7 @@ describe('Plugin Interaction Integration Tests', () => {
     it('should not impact performance when log level filters out messages', () => {
       setupTestContext();
       const mockLogger = vi.fn();
-      const logger = getLogger(mockLogger, JsonFormat);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: JsonFormat });
       logger.setLogLevel(AG_LOGLEVEL.ERROR);
 
       const iterations = 1000;
@@ -447,7 +447,7 @@ describe('Plugin Interaction Integration Tests', () => {
       });
       const formatterSpy = vi.fn().mockReturnValue('formatted message');
 
-      const logger = getLogger(throwingLogger, formatterSpy);
+      const logger = getLogger({ defaultLogger: throwingLogger, formatter: formatterSpy });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       expect(() => {
@@ -465,7 +465,7 @@ describe('Plugin Interaction Integration Tests', () => {
         throw new Error('Formatter error');
       });
 
-      const logger = getLogger(mockLogger, throwingFormatter);
+      const logger = getLogger({ defaultLogger: mockLogger, formatter: throwingFormatter });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       expect(() => {
@@ -482,7 +482,7 @@ describe('Plugin Interaction Integration Tests', () => {
         throw new Error('Temporary error');
       });
 
-      const logger = getLogger(throwingLogger, PlainFormat);
+      const logger = getLogger({ defaultLogger: throwingLogger, formatter: PlainFormat });
       logger.setLogLevel(AG_LOGLEVEL.INFO);
 
       // First call throws


### PR DESCRIPTION
## ✨ Overview

Refactored logger creation to use a more consistent and flexible `AgLogger.getLogger({ name, config })` pattern.  
Also updated import paths across test and source files to use the `@/` alias instead of relative `'../src/'`, improving module resolution clarity and reducing path complexity.

This change prepares the foundation for smoother plugin injection and enhanced logger control via the manager.

---

## 🔧 Changes

- [x] Refactored AgLoggerManager API to support cleaner `getLogger()` usage  
- [x] Unified logger access via options object syntax  
- [x] Replaced all `'../src/'` style imports with `@/` alias in test and doc files  
- [ ] Other: Improved test readability by aligning API usage  

---

## 📂 Related Issues

Related #121

---

## ✅ Checklist

- [x] Lint checks pass (`pnpm lint`)  
- [x] Tests pass (`pnpm test`)  
- [ ] Documentation is updated (if applicable)  
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)  
- [x] Descriptions and examples are clear  

---

## 💬 Additional Notes

This PR helps reduce relative path confusion, simplifies test setup, and aligns the logger interface with upcoming plugin-based designs.  
Please review especially the logger manager logic and its implications for downstream plugin work.
