### PR TITLE
refactor(ag-logger): add support for VERBOSE log level and improve test coverage

### DIFF
--- a/packages/@agla-utils/ag-logger/shared/types/AgLogLevel.types.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgLogLevel.types.ts
@@ -102,3 +102,26 @@ export type AgLogLevel = typeof AG_LOGLEVEL[keyof typeof AG_LOGLEVEL];
  * ```
  */
 export type AgLogLevelLabel = keyof typeof AG_LABEL_TO_LOGLEVEL_MAP;
+
+/**
+ * Log level key type derived from AG_LOGLEVEL keys.
+ * Represents all valid log level constant names.
+ *
+ * @example
+ * ```typescript
+ * const key: AgLogLevelKey = 'INFO'; // Valid
+ * const invalid: AgLogLevelKey = 'INVALID'; // Type error
+ * ```
+ */
+export type AgLogLevelKey = keyof typeof AG_LOGLEVEL;
+
+/**
+ * Array of all log level keys in AG_LOGLEVEL.
+ * Useful for iteration and functional programming operations.
+ *
+ * @example
+ * ```typescript
+ * AG_LOGLEVEL_KEYS.forEach(key => console.log(AG_LOGLEVEL[key]));
+ * ```
+ */
+export const AG_LOGLEVEL_KEYS = Object.keys(AG_LOGLEVEL) as AgLogLevelKey[];

--- a/packages/@agla-utils/ag-logger/shared/types/AgLogLevel.types.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgLogLevel.types.ts
@@ -34,6 +34,8 @@ export const AG_LOGLEVEL = {
   DEBUG: 5,
   /** Very detailed tracing information. */
   TRACE: 6,
+  /** special value: verbose mode  */
+  VERBOSE: -99,
 } as const;
 
 /**
@@ -60,6 +62,8 @@ export const AG_LABEL_TO_LOGLEVEL_MAP = {
   'DEBUG': AG_LOGLEVEL.DEBUG,
   /** Maps 'TRACE' string to numeric value 6. */
   'TRACE': AG_LOGLEVEL.TRACE,
+  /** Maps 'VERBOSE' string to numeric value -99. */
+  'VERBOSE': AG_LOGLEVEL.VERBOSE,
 } as const;
 
 /**

--- a/packages/@agla-utils/ag-logger/shared/types/AgLogger.interface.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgLogger.interface.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // type
-import type { AgLogMessage } from './AgLogger.types';
+import type { AgFormattedLogMessage, AgLogMessage } from './AgLogger.types';
 import type { AgLogLevel } from './AgLogLevel.types';
 
 // --- interfaces ---
@@ -23,7 +23,7 @@ import type { AgLogLevel } from './AgLogLevel.types';
  * const fileLogger: AgLoggerFunction = (message) => fs.appendFileSync('log.txt', message);
  * ```
  */
-export type AgLoggerFunction = (formattedLogMessage: string | AgLogMessage) => void;
+export type AgLoggerFunction = (formattedLogMessage: AgFormattedLogMessage) => void;
 
 /**
  * Represents a formatting function for log messages.
@@ -40,7 +40,7 @@ export type AgLoggerFunction = (formattedLogMessage: string | AgLogMessage) => v
  *   `${logMsg.timestamp} [${logMsg.level}] ${logMsg.message}`;
  * ```
  */
-export type AgFormatFunction = (logMessage: AgLogMessage) => string | AgLogMessage;
+export type AgFormatFunction = (logMessage: AgLogMessage) => AgFormattedLogMessage;
 
 /**
  * A map holding logging functions for each log level.

--- a/packages/@agla-utils/ag-logger/shared/types/AgLogger.interface.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgLogger.interface.ts
@@ -23,7 +23,7 @@ import type { AgLogLevel } from './AgLogLevel.types';
  * const fileLogger: AgLoggerFunction = (message) => fs.appendFileSync('log.txt', message);
  * ```
  */
-export type AgLoggerFunction = (formattedLogMessage: string) => void;
+export type AgLoggerFunction = (formattedLogMessage: string | AgLogMessage) => void;
 
 /**
  * Represents a formatting function for log messages.
@@ -40,7 +40,7 @@ export type AgLoggerFunction = (formattedLogMessage: string) => void;
  *   `${logMsg.timestamp} [${logMsg.level}] ${logMsg.message}`;
  * ```
  */
-export type AgFormatFunction = (logMessage: AgLogMessage) => string;
+export type AgFormatFunction = (logMessage: AgLogMessage) => string | AgLogMessage;
 
 /**
  * A map holding logging functions for each log level.

--- a/packages/@agla-utils/ag-logger/shared/types/AgLogger.types.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgLogger.types.ts
@@ -59,3 +59,15 @@ export type AgLogMessage = {
    */
   readonly args: readonly unknown[];
 };
+
+/**
+ * Type representing a formatted log message that can be either a string or AgLogMessage object.
+ * Used by logger functions and message collections in testing utilities.
+ */
+export type AgFormattedLogMessage = string | AgLogMessage;
+
+/**
+ * Type representing a collection of formatted log messages.
+ * Used by mock loggers and testing utilities to store logged messages.
+ */
+export type AgLogMessageCollection = AgFormattedLogMessage[];

--- a/packages/@agla-utils/ag-logger/shared/types/index.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/index.ts
@@ -6,7 +6,7 @@
 // https://opensource.org/licenses/MIT
 
 // constants
-export { AG_LABEL_TO_LOGLEVEL_MAP, AG_LOGLEVEL, AG_LOGLEVEL_TO_LABEL_MAP } from './AgLogLevel.types';
+export { AG_LABEL_TO_LOGLEVEL_MAP, AG_LOGLEVEL, AG_LOGLEVEL_KEYS, AG_LOGLEVEL_TO_LABEL_MAP } from './AgLogLevel.types';
 
 // types
 export type * from './AgLogger.types';

--- a/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
@@ -30,7 +30,7 @@ export class AgLogger {
   private _loggerManager: AgLoggerManager;
   private _verbose: boolean = false;
 
-  private constructor() {
+  protected constructor() {
     this._loggerManager = AgLoggerManager.getManager();
   }
 
@@ -105,7 +105,7 @@ export class AgLogger {
    * @param level - Log level of the message.
    * @param args - Arguments to be logged.
    */
-  private logWithLevel(level: AgLogLevel, ...args: unknown[]): void {
+  protected executeLog(level: AgLogLevel, ...args: unknown[]): void {
     if (this.isOutputLevel(level)) {
       const logMessage = AgLoggerGetMessage(level, ...args);
       const formatter = this._loggerManager.getFormatter();
@@ -139,37 +139,37 @@ export class AgLogger {
 
   /** Logs a message at FATAL level. */
   fatal(...args: unknown[]): void {
-    this.logWithLevel(AG_LOGLEVEL.FATAL, ...args);
+    this.executeLog(AG_LOGLEVEL.FATAL, ...args);
   }
 
   /** Logs a message at ERROR level. */
   error(...args: unknown[]): void {
-    this.logWithLevel(AG_LOGLEVEL.ERROR, ...args);
+    this.executeLog(AG_LOGLEVEL.ERROR, ...args);
   }
 
   /** Logs a message at WARN level. */
   warn(...args: unknown[]): void {
-    this.logWithLevel(AG_LOGLEVEL.WARN, ...args);
+    this.executeLog(AG_LOGLEVEL.WARN, ...args);
   }
 
   /** Logs a message at INFO level. */
   info(...args: unknown[]): void {
-    this.logWithLevel(AG_LOGLEVEL.INFO, ...args);
+    this.executeLog(AG_LOGLEVEL.INFO, ...args);
   }
 
   /** Logs a message at DEBUG level. */
   debug(...args: unknown[]): void {
-    this.logWithLevel(AG_LOGLEVEL.DEBUG, ...args);
+    this.executeLog(AG_LOGLEVEL.DEBUG, ...args);
   }
 
   /** Logs a message at TRACE level. */
   trace(...args: unknown[]): void {
-    this.logWithLevel(AG_LOGLEVEL.TRACE, ...args);
+    this.executeLog(AG_LOGLEVEL.TRACE, ...args);
   }
 
   /** General log method logging at INFO level. */
   log(...args: unknown[]): void {
-    this.logWithLevel(AG_LOGLEVEL.INFO, ...args);
+    this.executeLog(AG_LOGLEVEL.INFO, ...args);
   }
 
   /** Verbose log method that only outputs when verbose flag is true. */

--- a/packages/@agla-utils/ag-logger/src/AgLoggerManager.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLoggerManager.class.ts
@@ -17,8 +17,8 @@ import type {
 } from '../shared/types/AgLogger.interface';
 
 // plugins
-import { NullFormatter } from '@/plugins/formatter/NullFormatter';
-import { NullLogger } from '@/plugins/logger/NullLogger';
+import { NullFormatter } from './plugins/formatter/NullFormatter';
+import { NullLogger } from './plugins/logger/NullLogger';
 
 /**
  * Singleton manager class for handling loggers and formatters by log level.
@@ -34,6 +34,7 @@ export class AgLoggerManager {
     this.defaultLogger = NullLogger;
     this.formatter = NullFormatter;
     this.loggerMap = {
+      [AG_LOGLEVEL.VERBOSE]: NullLogger,
       [AG_LOGLEVEL.OFF]: NullLogger,
       [AG_LOGLEVEL.FATAL]: NullLogger,
       [AG_LOGLEVEL.ERROR]: NullLogger,

--- a/packages/@agla-utils/ag-logger/src/_types/__tests__/AgLoggerOptions.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/_types/__tests__/AgLoggerOptions.spec.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from 'vitest';
 
 // type imports
+import type { AgLogMessage } from '../../../shared/types';
 import type {
   AgFormatFunction,
   AgLoggerFunction,
@@ -41,7 +42,7 @@ describe('AgLoggerOptions Interface Tests', () => {
   describe('補助Task 1.1: AgLoggerOptionsの型定義が正しく動作することをテスト', () => {
     it('should accept valid AgLoggerOptions interface', () => {
       // テスト用のモック関数を作成
-      const mockLogger: AgLoggerFunction = (message: string) => console.log(message);
+      const mockLogger: AgLoggerFunction = (message: string | AgLogMessage) => console.log(message);
       const mockFormatter: AgFormatFunction = (logMessage) => `${logMessage.message}`;
 
       // 有効なオプションオブジェクトを作成
@@ -154,7 +155,7 @@ describe('AgLoggerOptions Interface Tests', () => {
       };
 
       const partialOptions3: AgLoggerOptions = {
-        defaultLogger: (msg: string) => console.log(msg),
+        defaultLogger: (msg: string | AgLogMessage) => console.log(msg),
         logLevel: AG_LOGLEVEL.DEBUG,
       };
 

--- a/packages/@agla-utils/ag-logger/src/functional/core/parseArgsToAgLogMessage.ts
+++ b/packages/@agla-utils/ag-logger/src/functional/core/parseArgsToAgLogMessage.ts
@@ -32,12 +32,22 @@ const isMessageArgument = (arg: unknown): arg is string | number | boolean | sym
 
 /**
  * Checks if an argument is a valid timestamp string.
+ * Only accepts ISO format or 'yyyy-mm-dd HH:MM:SS' format.
  *
  * @param arg - The argument to check
- * @returns True if the argument is a valid date string
+ * @returns True if the argument is a valid ISO timestamp or 'yyyy-mm-dd HH:MM:SS' format
  */
 const isTimestamp = (arg: unknown): arg is string => {
   if (typeof arg !== 'string') { return false; }
+
+  // Check for ISO timestamp format (strict)
+  const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?([+-]\d{2}:\d{2}|Z)$/;
+
+  // Check for 'yyyy-mm-dd HH:MM:SS' format
+  const standardPattern = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+
+  if (!isoPattern.test(arg) && !standardPattern.test(arg)) { return false; }
+
   const timestamp = new Date(arg);
   return !isNaN(timestamp.getTime());
 };

--- a/packages/@agla-utils/ag-logger/src/internal/__tests__/AgLoggerConfig.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/internal/__tests__/AgLoggerConfig.spec.ts
@@ -279,7 +279,7 @@ describe('AgLoggerConfig', () => {
     const config = new AgLoggerConfig();
 
     // Create a test logger function
-    const testLogger = (_message: string): void => {/* test logger */};
+    const testLogger = (_message: string | AgLogMessage): void => {/* test logger */};
 
     // Apply configuration with defaultLogger
     const options: AgLoggerOptions = {
@@ -337,7 +337,7 @@ describe('AgLoggerConfig', () => {
 
   it('should have setLogger method that can be called', () => {
     const config = new AgLoggerConfig();
-    const testLogger = (_message: string): void => {/* test logger */};
+    const testLogger = (_message: string | AgLogMessage): void => {/* test logger */};
 
     // Test that setLogger method exists and can be called
     expect(typeof config.setLogger).toBe('function');
@@ -350,7 +350,7 @@ describe('AgLoggerConfig', () => {
     const config = new AgLoggerConfig();
 
     // Create test logger
-    const testErrorLogger = (_message: string): void => {/* test error logger */};
+    const testErrorLogger = (_message: string | AgLogMessage): void => {/* test error logger */};
 
     // Verify initial state is NullLogger
     expect(config.getLoggerFunction(AG_LOGLEVEL.ERROR)).toBe(NullLogger);
@@ -368,9 +368,9 @@ describe('AgLoggerConfig', () => {
     const config = new AgLoggerConfig();
 
     // Create test loggers
-    const testErrorLogger = (_message: string): void => {/* test error logger */};
-    const testWarnLogger = (_message: string): void => {/* test warn logger */};
-    const testInfoLogger = (_message: string): void => {/* test info logger */};
+    const testErrorLogger = (_message: string | AgLogMessage): void => {/* test error logger */};
+    const testWarnLogger = (_message: string | AgLogMessage): void => {/* test warn logger */};
+    const testInfoLogger = (_message: string | AgLogMessage): void => {/* test info logger */};
 
     // Verify initial state
     expect(config.getLoggerFunction(AG_LOGLEVEL.ERROR)).toBe(NullLogger);
@@ -394,8 +394,8 @@ describe('AgLoggerConfig', () => {
     const config = new AgLoggerConfig();
 
     // Create test loggers
-    const testErrorLogger = (_message: string): void => {/* test error logger */};
-    const testWarnLogger = (_message: string): void => {/* test warn logger */};
+    const testErrorLogger = (_message: string | AgLogMessage): void => {/* test error logger */};
+    const testWarnLogger = (_message: string | AgLogMessage): void => {/* test warn logger */};
 
     // Verify initial state
     expect(config.getLoggerFunction(AG_LOGLEVEL.ERROR)).toBe(NullLogger);
@@ -421,8 +421,8 @@ describe('AgLoggerConfig', () => {
     const config = new AgLoggerConfig();
 
     // Create test loggers
-    const testDefaultLogger = (_message: string): void => {/* test default logger */};
-    const testErrorLogger = (_message: string): void => {/* test error logger */};
+    const testDefaultLogger = (_message: string | AgLogMessage): void => {/* test default logger */};
+    const testErrorLogger = (_message: string | AgLogMessage): void => {/* test error logger */};
 
     // Set a default logger via setLoggerConfig - this initializes all loggerMap entries
     const options: AgLoggerOptions = {
@@ -448,8 +448,8 @@ describe('AgLoggerConfig', () => {
     const config = new AgLoggerConfig();
 
     // Create test loggers
-    const testDefaultLogger = (_message: string): void => {/* test default logger */};
-    const testSpecificLogger = (_message: string): void => {/* test specific logger */};
+    const testDefaultLogger = (_message: string | AgLogMessage): void => {/* test default logger */};
+    const testSpecificLogger = (_message: string | AgLogMessage): void => {/* test specific logger */};
 
     // Set defaultLogger via setLoggerConfig which initializes all levels
     const options: AgLoggerOptions = {
@@ -476,8 +476,8 @@ describe('AgLoggerConfig', () => {
     const config = new AgLoggerConfig();
 
     // Create test loggers
-    const testDefaultLogger1 = (_message: string): void => {/* test default logger 1 */};
-    const testDefaultLogger2 = (_message: string): void => {/* test default logger 2 */};
+    const testDefaultLogger1 = (_message: string | AgLogMessage): void => {/* test default logger 1 */};
+    const testDefaultLogger2 = (_message: string | AgLogMessage): void => {/* test default logger 2 */};
 
     // Set first defaultLogger
     const options1: AgLoggerOptions = {
@@ -506,9 +506,9 @@ describe('AgLoggerConfig', () => {
     const config = new AgLoggerConfig();
 
     // Create test loggers
-    const testDefaultLogger = (_message: string): void => {/* test default logger */};
-    const testErrorLogger = (_message: string): void => {/* test error logger */};
-    const testWarnLogger = (_message: string): void => {/* test warn logger */};
+    const testDefaultLogger = (_message: string | AgLogMessage): void => {/* test default logger */};
+    const testErrorLogger = (_message: string | AgLogMessage): void => {/* test error logger */};
+    const testWarnLogger = (_message: string | AgLogMessage): void => {/* test warn logger */};
 
     // Apply configuration with both defaultLogger and loggerMap
     const options: AgLoggerOptions = {
@@ -572,7 +572,7 @@ describe('AgLoggerConfig', () => {
   describe('setLogger()', () => {
     it('should set logger function for specified log level', () => {
       const config = new AgLoggerConfig();
-      const testLogger = (_message: string): void => {/* test logger */};
+      const testLogger = (_message: string | AgLogMessage): void => {/* test logger */};
 
       config.setLogger(AG_LOGLEVEL.ERROR, testLogger);
       expect(config.getLoggerFunction(AG_LOGLEVEL.ERROR)).toBe(testLogger);
@@ -580,8 +580,8 @@ describe('AgLoggerConfig', () => {
 
     it('should set different logger functions for different levels', () => {
       const config = new AgLoggerConfig();
-      const testErrorLogger = (_message: string): void => {/* test error logger */};
-      const testWarnLogger = (_message: string): void => {/* test warn logger */};
+      const testErrorLogger = (_message: string | AgLogMessage): void => {/* test error logger */};
+      const testWarnLogger = (_message: string | AgLogMessage): void => {/* test warn logger */};
 
       config.setLogger(AG_LOGLEVEL.ERROR, testErrorLogger);
       config.setLogger(AG_LOGLEVEL.WARN, testWarnLogger);
@@ -594,7 +594,7 @@ describe('AgLoggerConfig', () => {
 
     it('should throw AgLoggerError for invalid log levels', () => {
       const config = new AgLoggerConfig();
-      const testLogger = (_message: string): void => {/* test logger */};
+      const testLogger = (_message: string | AgLogMessage): void => {/* test logger */};
 
       expect(() => config.setLogger(999 as AgLogLevel, testLogger)).toThrow(AgLoggerError);
       expect(() => config.setLogger(-1 as AgLogLevel, testLogger)).toThrow(AgLoggerError);
@@ -605,7 +605,7 @@ describe('AgLoggerConfig', () => {
 
     it('should throw error with correct error category and message', () => {
       const config = new AgLoggerConfig();
-      const testLogger = (_message: string): void => {/* test logger */};
+      const testLogger = (_message: string | AgLogMessage): void => {/* test logger */};
 
       try {
         config.setLogger(999 as AgLogLevel, testLogger);
@@ -618,8 +618,8 @@ describe('AgLoggerConfig', () => {
 
     it('should allow overwriting existing logger for same level', () => {
       const config = new AgLoggerConfig();
-      const firstLogger = (_message: string): void => {/* first logger */};
-      const secondLogger = (_message: string): void => {/* second logger */};
+      const firstLogger = (_message: string | AgLogMessage): void => {/* first logger */};
+      const secondLogger = (_message: string | AgLogMessage): void => {/* second logger */};
 
       config.setLogger(AG_LOGLEVEL.ERROR, firstLogger);
       expect(config.getLoggerFunction(AG_LOGLEVEL.ERROR)).toBe(firstLogger);

--- a/packages/@agla-utils/ag-logger/src/internal/__tests__/AgLoggerConfig.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/internal/__tests__/AgLoggerConfig.spec.ts
@@ -59,17 +59,17 @@ describe('AgLoggerConfig', () => {
 
   it('should initialize with NullFormatter as default formatter', () => {
     const config = new AgLoggerConfig();
-    expect(config._formatter).toBe(NullFormatter);
+    expect(config.getFormatter()).toBe(NullFormatter);
   });
 
   it('should initialize with AG_LOGLEVEL.OFF as default log level', () => {
     const config = new AgLoggerConfig();
-    expect(config._logLevel).toBe(AG_LOGLEVEL.OFF);
+    expect(config.getLogLevel()).toBe(AG_LOGLEVEL.OFF);
   });
 
   it('should initialize with verbose as false', () => {
     const config = new AgLoggerConfig();
-    expect(config._verbose).toBe(DISABLE);
+    expect(config.getVerbose()).toBe(DISABLE);
   });
 
   it('should initialize all log levels with NullLogger', () => {
@@ -306,7 +306,7 @@ describe('AgLoggerConfig', () => {
     config.setLoggerConfig(options);
 
     // Verify formatter was applied
-    expect(config._formatter).toBe(testFormatter);
+    expect(config.getFormatter()).toBe(testFormatter);
   });
 
   it('should apply logLevel setting', () => {

--- a/packages/@agla-utils/ag-logger/src/plugins/formatter/MockFormatter.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/formatter/MockFormatter.ts
@@ -1,0 +1,40 @@
+// src/plugins/formatter/MockFormatter.ts
+// @(#) : Mock Formatter for Testing
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// types
+import type { AgFormatFunction, AgLogMessage } from '../../../shared/types';
+
+/**
+ * Mock formatters for testing purposes.
+ * Contains simple formatter functions that can be used in unit tests.
+ */
+export const MockFormatter = {
+  /**
+   * Passthrough formatter that returns the log message as-is.
+   * Useful for testing when you want to verify the raw AgLogMessage object.
+   *
+   * @param logMessage - The log message object
+   * @returns The same log message object unchanged
+   */
+  passthrough: ((logMessage: AgLogMessage): AgLogMessage => {
+    return logMessage;
+  }) as AgFormatFunction,
+
+  /**
+   * JSON formatter that converts the log message to a JSON string.
+   * Simple implementation for testing JSON serialization.
+   *
+   * @param logMessage - The log message object
+   * @returns JSON string representation of the log message
+   */
+  json: ((logMessage: AgLogMessage): string => {
+    return JSON.stringify(logMessage);
+  }) as AgFormatFunction,
+} as const;
+
+export default MockFormatter;

--- a/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/MockFormatter.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/MockFormatter.spec.ts
@@ -1,0 +1,439 @@
+// src/plugins/formatter/__tests__/MockFormatter.spec.ts
+// @(#) : Unit tests for MockFormatter plugin
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// vitest imports
+import { describe, expect, it } from 'vitest';
+
+// constants
+import { AG_LOGLEVEL } from '../../../../shared/types';
+// types
+import type { AgLogMessage } from '../../../../shared/types/AgLogger.types';
+
+// subject under test
+import { MockFormatter } from '../MockFormatter';
+
+/**
+ * MockFormatterプラグインのユニットテストスイート
+ *
+ * @description MockFormatterの2つのフォーマッター関数をテストする:
+ * - passthrough: AgLogMessageオブジェクトをそのまま返す
+ * - json: AgLogMessageをJSON文字列に変換する
+ *
+ * @testType Unit Test
+ * @testTarget MockFormatter Plugin
+ * @coverage
+ * - passthrough フォーマッターの同一オブジェクト参照返却
+ * - passthrough フォーマッターのオブジェクトプロパティ保持
+ * - passthrough フォーマッターの様々なAgLogMessage構造での動作
+ * - passthrough フォーマッターの全ログレベルでの動作
+ * - passthrough フォーマッターのエッジケース処理
+ * - json フォーマッターの文字列型返却
+ * - json フォーマッターの有効なJSON文字列出力
+ * - json フォーマッターの解析可能性
+ * - json フォーマッターのシリアライゼーション内容
+ * - json フォーマッターの引数処理
+ * - json フォーマッターの全ログレベルでの動作
+ * - json フォーマッターの複雑な引数構造処理
+ * - json フォーマッターのエッジケース処理
+ * - json フォーマッターの循環参照エラー処理
+ * - TypeScript型安全性の保証
+ */
+describe('MockFormatter', () => {
+  describe('passthrough formatter', () => {
+    /**
+     * Tests that passthrough formatter returns the exact same object reference.
+     */
+    it('returns the exact same object reference', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.INFO,
+        timestamp: new Date('2025-01-01T12:00:00.000Z'),
+        message: 'Test message',
+        args: [],
+      };
+
+      // Act
+      const result = MockFormatter.passthrough(logMessage) as AgLogMessage;
+
+      // Assert
+      expect(result).toBe(logMessage); // Same reference
+      expect(result === logMessage).toBe(true); // Strict equality
+    });
+
+    /**
+     * Tests that passthrough formatter preserves all object properties unchanged.
+     */
+    it('preserves all object properties unchanged', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.DEBUG,
+        timestamp: new Date('2025-06-15T14:30:45.123Z'),
+        message: 'Debug message with data',
+        args: [{ userId: 123, action: 'click' }],
+      };
+
+      // Act
+      const result = MockFormatter.passthrough(logMessage) as AgLogMessage;
+
+      // Assert
+      expect(result.logLevel).toBe(AG_LOGLEVEL.DEBUG);
+      expect(result.timestamp).toEqual(new Date('2025-06-15T14:30:45.123Z'));
+      expect(result.message).toBe('Debug message with data');
+      expect(result.args).toEqual([{ userId: 123, action: 'click' }]);
+    });
+
+    /**
+     * Tests that passthrough formatter handles AgLogMessage with empty args array.
+     */
+    it('handles AgLogMessage with empty args array', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.WARN,
+        timestamp: new Date('2025-03-20T08:15:30.000Z'),
+        message: 'Warning without additional data',
+        args: [],
+      };
+
+      // Act
+      const result = MockFormatter.passthrough(logMessage) as AgLogMessage;
+
+      // Assert
+      expect(result).toBe(logMessage);
+      expect(result.args).toEqual([]);
+      expect(Array.isArray(result.args)).toBe(true);
+    });
+
+    /**
+     * Tests that passthrough formatter handles AgLogMessage with complex args structures.
+     */
+    it('handles AgLogMessage with complex args structures', () => {
+      // Arrange
+      const complexArgs = [
+        { nested: { deep: { value: 'test' } } },
+        ['array', 'of', 'strings'],
+        42,
+        true,
+        null,
+        undefined,
+      ];
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.TRACE,
+        timestamp: new Date('2025-09-10T16:45:00.567Z'),
+        message: 'Complex data structure',
+        args: complexArgs,
+      };
+
+      // Act
+      const result = MockFormatter.passthrough(logMessage) as AgLogMessage;
+
+      // Assert
+      expect(result).toBe(logMessage);
+      expect(result.args).toBe(complexArgs); // Same reference for args
+      expect(result.args).toEqual(complexArgs); // Same content
+    });
+
+    /**
+     * Tests that passthrough formatter works correctly with all log levels.
+     */
+    it('works correctly with all log levels', () => {
+      // Arrange
+      const baseMessage: Omit<AgLogMessage, 'logLevel'> = {
+        timestamp: new Date('2025-01-01T00:00:00.000Z'),
+        message: 'Test message',
+        args: [],
+      };
+
+      const testCases = [
+        AG_LOGLEVEL.OFF,
+        AG_LOGLEVEL.FATAL,
+        AG_LOGLEVEL.ERROR,
+        AG_LOGLEVEL.WARN,
+        AG_LOGLEVEL.INFO,
+        AG_LOGLEVEL.DEBUG,
+        AG_LOGLEVEL.TRACE,
+      ];
+
+      testCases.forEach((level) => {
+        // Arrange
+        const logMessage = { ...baseMessage, logLevel: level };
+
+        // Act
+        const result = MockFormatter.passthrough(logMessage) as AgLogMessage;
+
+        // Assert
+        expect(result).toBe(logMessage);
+        expect(result.logLevel).toBe(level);
+      });
+    });
+
+    /**
+     * Tests that passthrough formatter handles edge cases.
+     */
+    it('handles edge cases with empty message and special timestamps', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.ERROR,
+        timestamp: new Date('1970-01-01T00:00:00.000Z'), // Unix epoch
+        message: '', // Empty message
+        args: [{ error: 'critical failure' }],
+      };
+
+      // Act
+      const result = MockFormatter.passthrough(logMessage) as AgLogMessage;
+
+      // Assert
+      expect(result).toBe(logMessage);
+      expect(result.message).toBe('');
+      expect(result.timestamp.getTime()).toBe(0); // Unix epoch timestamp
+    });
+  });
+
+  describe('json formatter', () => {
+    /**
+     * Tests that json formatter returns a string type.
+     */
+    it('returns a string type', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.INFO,
+        timestamp: new Date('2025-01-01T12:00:00.000Z'),
+        message: 'Test message',
+        args: [],
+      };
+
+      // Act
+      const result = MockFormatter.json(logMessage) as string;
+
+      // Assert
+      expect(typeof result).toBe('string');
+      expect(result).toBeTypeOf('string');
+    });
+
+    /**
+     * Tests that json formatter returns parseable JSON string.
+     */
+    it('returns parseable JSON string', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.INFO,
+        timestamp: new Date('2025-01-01T12:00:00.000Z'),
+        message: 'Test message',
+        args: [],
+      };
+
+      // Act
+      const result = MockFormatter.json(logMessage) as string;
+
+      // Assert
+      expect(() => JSON.parse(result)).not.toThrow();
+      const parsed = JSON.parse(result);
+      expect(typeof parsed).toBe('object');
+      expect(parsed).not.toBeNull();
+    });
+
+    /**
+     * Tests that json formatter produces JSON with correct serialized content.
+     */
+    it('produces JSON with correct serialized content', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.WARN,
+        timestamp: new Date('2025-04-15T10:30:15.456Z'),
+        message: 'Warning message',
+        args: [{ userId: 789, status: 'active' }],
+      };
+
+      // Act
+      const result = MockFormatter.json(logMessage) as string;
+      const parsed = JSON.parse(result);
+
+      // Assert
+      expect(parsed.logLevel).toBe(AG_LOGLEVEL.WARN);
+      expect(parsed.timestamp).toBe('2025-04-15T10:30:15.456Z');
+      expect(parsed.message).toBe('Warning message');
+      expect(parsed.args).toEqual([{ userId: 789, status: 'active' }]);
+    });
+
+    /**
+     * Tests that json formatter correctly serializes AgLogMessage with args.
+     */
+    it('correctly serializes AgLogMessage with args', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.ERROR,
+        timestamp: new Date('2025-07-22T18:45:30.789Z'),
+        message: 'Error occurred',
+        args: [
+          { errorCode: 500 },
+          { stack: 'Error at line 42' },
+          'additional context',
+        ],
+      };
+
+      // Act
+      const result = MockFormatter.json(logMessage) as string;
+      const parsed = JSON.parse(result);
+
+      // Assert
+      expect(parsed.args).toEqual([
+        { errorCode: 500 },
+        { stack: 'Error at line 42' },
+        'additional context',
+      ]);
+      expect(Array.isArray(parsed.args)).toBe(true);
+      expect(parsed.args.length).toBe(3);
+    });
+
+    /**
+     * Tests that json formatter works correctly with all log levels.
+     */
+    it('works correctly with all log levels', () => {
+      // Arrange
+      const baseMessage: Omit<AgLogMessage, 'logLevel'> = {
+        timestamp: new Date('2025-01-01T00:00:00.000Z'),
+        message: 'Test message',
+        args: [],
+      };
+
+      const testCases = [
+        AG_LOGLEVEL.OFF,
+        AG_LOGLEVEL.FATAL,
+        AG_LOGLEVEL.ERROR,
+        AG_LOGLEVEL.WARN,
+        AG_LOGLEVEL.INFO,
+        AG_LOGLEVEL.DEBUG,
+        AG_LOGLEVEL.TRACE,
+      ];
+
+      testCases.forEach((level) => {
+        // Arrange
+        const logMessage = { ...baseMessage, logLevel: level };
+
+        // Act
+        const result = MockFormatter.json(logMessage) as string;
+        const parsed = JSON.parse(result);
+
+        // Assert
+        expect(parsed.logLevel).toBe(level);
+        expect(typeof result).toBe('string');
+        expect(() => JSON.parse(result)).not.toThrow();
+      });
+    });
+
+    /**
+     * Tests that json formatter handles complex args structures.
+     */
+    it('handles complex args structures with objects, arrays, and nested data', () => {
+      // Arrange
+      const complexArgs = [
+        {
+          user: { id: 123, name: 'John Doe', roles: ['admin', 'user'] },
+          metadata: { version: '1.0.0', timestamp: '2025-01-01' },
+        },
+        [1, 2, { nested: [3, 4, 5] }],
+        'simple string',
+        42,
+        true,
+        null,
+      ];
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.DEBUG,
+        timestamp: new Date('2025-05-10T13:20:45.321Z'),
+        message: 'Complex nested data',
+        args: complexArgs,
+      };
+
+      // Act
+      const result = MockFormatter.json(logMessage) as string;
+      const parsed = JSON.parse(result);
+
+      // Assert
+      expect(parsed.args).toEqual(complexArgs);
+      expect(parsed.args[0].user.roles).toEqual(['admin', 'user']);
+      expect(parsed.args[1][2].nested).toEqual([3, 4, 5]);
+    });
+
+    /**
+     * Tests that json formatter handles edge cases with empty message and special characters.
+     */
+    it('handles edge cases with empty message and special characters', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.TRACE,
+        timestamp: new Date('2025-12-31T23:59:59.999Z'),
+        message: '', // Empty message
+        args: [
+          { text: 'Special chars: "\\n\\t\\r\\' },
+          { unicode: '🚀 Unicode test 日本語' },
+        ],
+      };
+
+      // Act
+      const result = MockFormatter.json(logMessage) as string;
+      const parsed = JSON.parse(result);
+
+      // Assert
+      expect(parsed.message).toBe('');
+      expect(parsed.args[0].text).toBe('Special chars: "\\n\\t\\r\\');
+      expect(parsed.args[1].unicode).toBe('🚀 Unicode test 日本語');
+    });
+
+    /**
+     * Tests that json formatter throws appropriate error for circular references.
+     */
+    it('throws appropriate error for circular references', () => {
+      // Arrange
+      const circularObj: { name: string; self?: unknown } = { name: 'test' };
+      circularObj.self = circularObj; // Create circular reference
+
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.ERROR,
+        timestamp: new Date('2025-01-01T12:00:00.000Z'),
+        message: 'Circular reference test',
+        args: [circularObj],
+      };
+
+      // Act & Assert
+      expect(() => MockFormatter.json(logMessage)).toThrow();
+      expect(() => MockFormatter.json(logMessage)).toThrow(/circular/i);
+    });
+  });
+
+  describe('type safety', () => {
+    /**
+     * Tests that both formatters maintain proper TypeScript type safety.
+     */
+    it('maintains proper TypeScript type safety for both formatters', () => {
+      // Arrange
+      const logMessage: AgLogMessage = {
+        logLevel: AG_LOGLEVEL.INFO,
+        timestamp: new Date('2025-01-01T12:00:00.000Z'),
+        message: 'Type safety test',
+        args: [{ typed: 'data' }],
+      };
+
+      // Act
+      const passthroughResult = MockFormatter.passthrough(logMessage);
+      const jsonResult = MockFormatter.json(logMessage);
+
+      // Assert type compatibility
+      expect(passthroughResult).toSatisfy((result: AgLogMessage) => {
+        return (
+          typeof result.logLevel === 'number'
+          && result.timestamp instanceof Date
+          && typeof result.message === 'string'
+          && Array.isArray(result.args)
+        );
+      });
+
+      expect(jsonResult).toSatisfy((result: string) => {
+        return typeof result === 'string';
+      });
+    });
+  });
+});

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/ConsoleLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/ConsoleLogger.ts
@@ -10,6 +10,7 @@
 // constants
 import { AG_LOGLEVEL } from '../../../shared/types';
 // types
+import type { AgFormattedLogMessage } from '../../../shared/types';
 import type { AgLoggerFunction, AgLoggerMap } from '../../../shared/types/AgLogger.interface';
 
 // logger if log level is OFF
@@ -21,7 +22,7 @@ import { NullLogger } from './NullLogger';
  *
  * @param formattedLogMessage - The formatted log message to be logged.
  */
-export const ConsoleLogger: AgLoggerFunction = (formattedLogMessage: string) => {
+export const ConsoleLogger: AgLoggerFunction = (formattedLogMessage: AgFormattedLogMessage) => {
   console.log(formattedLogMessage);
 };
 
@@ -31,22 +32,22 @@ export const ConsoleLogger: AgLoggerFunction = (formattedLogMessage: string) => 
  */
 export const ConsoleLoggerMap: AgLoggerMap = {
   [AG_LOGLEVEL.OFF]: NullLogger,
-  [AG_LOGLEVEL.FATAL]: (formattedMessage: string) => {
+  [AG_LOGLEVEL.FATAL]: (formattedMessage: AgFormattedLogMessage) => {
     console.error(formattedMessage);
   },
-  [AG_LOGLEVEL.ERROR]: (formattedMessage: string) => {
+  [AG_LOGLEVEL.ERROR]: (formattedMessage: AgFormattedLogMessage) => {
     console.error(formattedMessage);
   },
-  [AG_LOGLEVEL.WARN]: (formattedMessage: string) => {
+  [AG_LOGLEVEL.WARN]: (formattedMessage: AgFormattedLogMessage) => {
     console.warn(formattedMessage);
   },
-  [AG_LOGLEVEL.INFO]: (formattedMessage: string) => {
+  [AG_LOGLEVEL.INFO]: (formattedMessage: AgFormattedLogMessage) => {
     console.info(formattedMessage);
   },
-  [AG_LOGLEVEL.DEBUG]: (formattedMessage: string) => {
+  [AG_LOGLEVEL.DEBUG]: (formattedMessage: AgFormattedLogMessage) => {
     console.debug(formattedMessage);
   },
-  [AG_LOGLEVEL.TRACE]: (formattedMessage: string) => {
+  [AG_LOGLEVEL.TRACE]: (formattedMessage: AgFormattedLogMessage) => {
     console.debug(formattedMessage);
   },
 };

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/ConsoleLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/ConsoleLogger.ts
@@ -31,6 +31,9 @@ export const ConsoleLogger: AgLoggerFunction = (formattedLogMessage: AgFormatted
  * Uses appropriate console methods per log level for better log categorization.
  */
 export const ConsoleLoggerMap: AgLoggerMap = {
+  [AG_LOGLEVEL.VERBOSE]: (formattedMessage: AgFormattedLogMessage) => {
+    console.debug(formattedMessage);
+  },
   [AG_LOGLEVEL.OFF]: NullLogger,
   [AG_LOGLEVEL.FATAL]: (formattedMessage: AgFormattedLogMessage) => {
     console.error(formattedMessage);

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
@@ -12,7 +12,14 @@ import { MockLogger } from './MockLogger';
 
 // types
 import { AG_LOGLEVEL } from '../../../shared/types';
-import type { AgLoggerFunction, AgLoggerMap, AgLogLevel } from '../../../shared/types';
+import type {
+  AgFormattedLogMessage,
+  AgLoggerFunction,
+  AgLoggerMap,
+  AgLogLevel,
+  AgLogMessage,
+  AgLogMessageCollection,
+} from '../../../shared/types';
 
 /**
  * Mock logger for E2E testing that supports parallel test execution.
@@ -41,7 +48,7 @@ export class E2eMockLogger {
   /**
    * Get the current test ID for this logger instance.
    */
-  getCurrentTestId(): string | null {
+  getCurrentTestId(): string | AgLogMessage | null {
     return this.currentTestId;
   }
 
@@ -82,32 +89,32 @@ export class E2eMockLogger {
   }
 
   // Logger methods
-  fatal(message: string): void {
+  fatal(message: AgFormattedLogMessage): void {
     const mockLogger = this.getCurrentMockLogger();
     mockLogger.fatal(message);
   }
 
-  error(message: string): void {
+  error(message: AgFormattedLogMessage): void {
     const mockLogger = this.getCurrentMockLogger();
     mockLogger.error(message);
   }
 
-  warn(message: string): void {
+  warn(message: AgFormattedLogMessage): void {
     const mockLogger = this.getCurrentMockLogger();
     mockLogger.warn(message);
   }
 
-  info(message: string): void {
+  info(message: AgFormattedLogMessage): void {
     const mockLogger = this.getCurrentMockLogger();
     mockLogger.info(message);
   }
 
-  debug(message: string): void {
+  debug(message: AgFormattedLogMessage): void {
     const mockLogger = this.getCurrentMockLogger();
     mockLogger.debug(message);
   }
 
-  trace(message: string): void {
+  trace(message: AgFormattedLogMessage): void {
     const mockLogger = this.getCurrentMockLogger();
     mockLogger.trace(message);
   }
@@ -130,12 +137,12 @@ export class E2eMockLogger {
   }
 
   // Query methods
-  getMessages(logLevel: AgLogLevel): string[] {
+  getMessages(logLevel: AgLogLevel): AgLogMessageCollection {
     const mockLogger = this.getCurrentMockLogger();
     return mockLogger.getMessages(logLevel);
   }
 
-  getLastMessage(logLevel: AgLogLevel): string | null {
+  getLastMessage(logLevel: AgLogLevel): string | AgLogMessage | null {
     const mockLogger = this.getCurrentMockLogger();
     return mockLogger.getLastMessage(logLevel);
   }
@@ -146,12 +153,12 @@ export class E2eMockLogger {
   }
 
   // Error-specific convenience methods
-  getErrorMessages(): string[] {
+  getErrorMessages(): AgLogMessageCollection {
     const mockLogger = this.getCurrentMockLogger();
     return mockLogger.getErrorMessages();
   }
 
-  getLastErrorMessage(): string | null {
+  getLastErrorMessage(): string | AgLogMessage | null {
     const mockLogger = this.getCurrentMockLogger();
     return mockLogger.getLastErrorMessage();
   }
@@ -164,7 +171,7 @@ export class E2eMockLogger {
   /**
    * Get all messages for all log levels.
    */
-  getAllMessages(): { [K in keyof typeof AG_LOGLEVEL]: string[] } {
+  getAllMessages(): { [K in keyof typeof AG_LOGLEVEL]: AgLogMessageCollection } {
     const mockLogger = this.getCurrentMockLogger();
     return mockLogger.getAllMessages();
   }
@@ -182,7 +189,7 @@ export class E2eMockLogger {
    * This can be used as a plugin for ag-logger.
    */
   createLoggerFunction(): AgLoggerFunction {
-    return (formattedLogMessage: string): void => {
+    return (formattedLogMessage: AgFormattedLogMessage): void => {
       const mockLogger = this.getCurrentMockLogger();
       mockLogger.info(formattedLogMessage);
     };
@@ -195,12 +202,12 @@ export class E2eMockLogger {
   createLoggerMap(): AgLoggerMap {
     return {
       [AG_LOGLEVEL.OFF]: () => {},
-      [AG_LOGLEVEL.FATAL]: (message: string) => this.fatal(message),
-      [AG_LOGLEVEL.ERROR]: (message: string) => this.error(message),
-      [AG_LOGLEVEL.WARN]: (message: string) => this.warn(message),
-      [AG_LOGLEVEL.INFO]: (message: string) => this.info(message),
-      [AG_LOGLEVEL.DEBUG]: (message: string) => this.debug(message),
-      [AG_LOGLEVEL.TRACE]: (message: string) => this.trace(message),
+      [AG_LOGLEVEL.FATAL]: (message: AgFormattedLogMessage) => this.fatal(message),
+      [AG_LOGLEVEL.ERROR]: (message: AgFormattedLogMessage) => this.error(message),
+      [AG_LOGLEVEL.WARN]: (message: AgFormattedLogMessage) => this.warn(message),
+      [AG_LOGLEVEL.INFO]: (message: AgFormattedLogMessage) => this.info(message),
+      [AG_LOGLEVEL.DEBUG]: (message: AgFormattedLogMessage) => this.debug(message),
+      [AG_LOGLEVEL.TRACE]: (message: AgFormattedLogMessage) => this.trace(message),
     };
   }
 }

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
@@ -33,7 +33,7 @@ export class E2eMockLogger {
 
   constructor(identifier?: string) {
     const trimmedIdentifier = typeof identifier === 'string' ? identifier.trim() : '';
-    this.testIdentifier = trimmedIdentifier ? getNormalizedBasename(trimmedIdentifier) : 'e2edefault';
+    this.testIdentifier = trimmedIdentifier ? getNormalizedBasename(trimmedIdentifier) : 'e2e-default';
     this.currentTestId = null;
     this.mockLoggers = new Map<string, MockLogger>();
   }
@@ -119,6 +119,11 @@ export class E2eMockLogger {
     mockLogger.trace(message);
   }
 
+  verbose(message: AgFormattedLogMessage): void {
+    const mockLogger = this.getCurrentMockLogger();
+    mockLogger.verbose(message);
+  }
+
   /**
    * Get the MockLogger instance for the current test.
    * Validates that there is an active test before returning.
@@ -150,22 +155,6 @@ export class E2eMockLogger {
   clearMessages(logLevel: AgLogLevel): void {
     const mockLogger = this.getCurrentMockLogger();
     mockLogger.clearMessages(logLevel);
-  }
-
-  // Error-specific convenience methods
-  getErrorMessages(): AgLogMessageCollection {
-    const mockLogger = this.getCurrentMockLogger();
-    return mockLogger.getErrorMessages();
-  }
-
-  getLastErrorMessage(): string | AgLogMessage | null {
-    const mockLogger = this.getCurrentMockLogger();
-    return mockLogger.getLastErrorMessage();
-  }
-
-  clearErrorMessages(): void {
-    const mockLogger = this.getCurrentMockLogger();
-    mockLogger.clearErrorMessages();
   }
 
   /**
@@ -201,6 +190,7 @@ export class E2eMockLogger {
    */
   createLoggerMap(): AgLoggerMap {
     return {
+      [AG_LOGLEVEL.VERBOSE]: (message: AgFormattedLogMessage) => this.verbose(message),
       [AG_LOGLEVEL.OFF]: () => {},
       [AG_LOGLEVEL.FATAL]: (message: AgFormattedLogMessage) => this.fatal(message),
       [AG_LOGLEVEL.ERROR]: (message: AgFormattedLogMessage) => this.error(message),

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/MockLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/MockLogger.ts
@@ -8,7 +8,13 @@
 
 // types
 import { AG_LOGLEVEL } from '../../../shared/types';
-import type { AgLoggerFunction, AgLoggerMap, AgLogLevel, AgLogMessage } from '../../../shared/types';
+import type {
+  AgFormattedLogMessage,
+  AgLoggerFunction,
+  AgLoggerMap,
+  AgLogLevel,
+  AgLogMessage,
+} from '../../../shared/types';
 
 /**
  * Universal mock logger for unit and integration testing.
@@ -21,7 +27,7 @@ import type { AgLoggerFunction, AgLoggerMap, AgLogLevel, AgLogMessage } from '..
  * - Thread-safe for single-threaded test scenarios
  */
 export class MockLogger {
-  private messages: (AgLogMessage | string)[][] = [
+  private messages: AgFormattedLogMessage[][] = [
     [], // OFF (0) - not used for actual logging
     [], // FATAL (1)
     [], // ERROR (2)
@@ -43,32 +49,32 @@ export class MockLogger {
   }
 
   // Logger methods
-  fatal(message: AgLogMessage | string): void {
+  fatal(message: AgFormattedLogMessage): void {
     this.messages[AG_LOGLEVEL.FATAL].push(message);
   }
 
-  error(message: AgLogMessage | string): void {
+  error(message: AgFormattedLogMessage): void {
     this.messages[AG_LOGLEVEL.ERROR].push(message);
   }
 
-  warn(message: AgLogMessage | string): void {
+  warn(message: AgFormattedLogMessage): void {
     this.messages[AG_LOGLEVEL.WARN].push(message);
   }
 
-  info(message: AgLogMessage | string): void {
+  info(message: AgFormattedLogMessage): void {
     this.messages[AG_LOGLEVEL.INFO].push(message);
   }
 
-  debug(message: AgLogMessage | string): void {
+  debug(message: AgFormattedLogMessage): void {
     this.messages[AG_LOGLEVEL.DEBUG].push(message);
   }
 
-  trace(message: AgLogMessage | string): void {
+  trace(message: AgFormattedLogMessage): void {
     this.messages[AG_LOGLEVEL.TRACE].push(message);
   }
 
   // Query methods
-  getMessages(logLevel: AgLogLevel): (AgLogMessage | string)[] {
+  getMessages(logLevel: AgLogLevel): AgFormattedLogMessage[] {
     this.validateLogLevel(logLevel);
     return [...this.messages[logLevel]];
   }
@@ -79,7 +85,7 @@ export class MockLogger {
     return levelMessages[levelMessages.length - 1] || null;
   }
 
-  getAllMessages(): { [K in keyof typeof AG_LOGLEVEL]: (AgLogMessage | string)[] } {
+  getAllMessages(): { [K in keyof typeof AG_LOGLEVEL]: AgFormattedLogMessage[] } {
     return {
       OFF: [...this.messages[AG_LOGLEVEL.OFF]],
       FATAL: [...this.messages[AG_LOGLEVEL.FATAL]],
@@ -155,7 +161,7 @@ export class MockLogger {
   }
 
   // Legacy methods for backward compatibility
-  getErrorMessages(): (AgLogMessage | string)[] {
+  getErrorMessages(): AgFormattedLogMessage[] {
     return this.getMessages(AG_LOGLEVEL.ERROR);
   }
 

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/MockLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/MockLogger.ts
@@ -8,7 +8,7 @@
 
 // types
 import { AG_LOGLEVEL } from '../../../shared/types';
-import type { AgLoggerFunction, AgLoggerMap, AgLogLevel } from '../../../shared/types';
+import type { AgLoggerFunction, AgLoggerMap, AgLogLevel, AgLogMessage } from '../../../shared/types';
 
 /**
  * Universal mock logger for unit and integration testing.
@@ -21,7 +21,7 @@ import type { AgLoggerFunction, AgLoggerMap, AgLogLevel } from '../../../shared/
  * - Thread-safe for single-threaded test scenarios
  */
 export class MockLogger {
-  private messages: string[][] = [
+  private messages: (AgLogMessage | string)[][] = [
     [], // OFF (0) - not used for actual logging
     [], // FATAL (1)
     [], // ERROR (2)
@@ -43,43 +43,43 @@ export class MockLogger {
   }
 
   // Logger methods
-  fatal(message: string): void {
+  fatal(message: AgLogMessage | string): void {
     this.messages[AG_LOGLEVEL.FATAL].push(message);
   }
 
-  error(message: string): void {
+  error(message: AgLogMessage | string): void {
     this.messages[AG_LOGLEVEL.ERROR].push(message);
   }
 
-  warn(message: string): void {
+  warn(message: AgLogMessage | string): void {
     this.messages[AG_LOGLEVEL.WARN].push(message);
   }
 
-  info(message: string): void {
+  info(message: AgLogMessage | string): void {
     this.messages[AG_LOGLEVEL.INFO].push(message);
   }
 
-  debug(message: string): void {
+  debug(message: AgLogMessage | string): void {
     this.messages[AG_LOGLEVEL.DEBUG].push(message);
   }
 
-  trace(message: string): void {
+  trace(message: AgLogMessage | string): void {
     this.messages[AG_LOGLEVEL.TRACE].push(message);
   }
 
   // Query methods
-  getMessages(logLevel: AgLogLevel): string[] {
+  getMessages(logLevel: AgLogLevel): (AgLogMessage | string)[] {
     this.validateLogLevel(logLevel);
     return [...this.messages[logLevel]];
   }
 
-  getLastMessage(logLevel: AgLogLevel): string | null {
+  getLastMessage(logLevel: AgLogLevel): AgLogMessage | string | null {
     this.validateLogLevel(logLevel);
     const levelMessages = this.messages[logLevel];
     return levelMessages[levelMessages.length - 1] || null;
   }
 
-  getAllMessages(): { [K in keyof typeof AG_LOGLEVEL]: string[] } {
+  getAllMessages(): { [K in keyof typeof AG_LOGLEVEL]: (AgLogMessage | string)[] } {
     return {
       OFF: [...this.messages[AG_LOGLEVEL.OFF]],
       FATAL: [...this.messages[AG_LOGLEVEL.FATAL]],
@@ -132,7 +132,7 @@ export class MockLogger {
    * This can be used as a plugin for ag-logger.
    */
   createLoggerFunction(): AgLoggerFunction {
-    return (formattedLogMessage: string): void => {
+    return (formattedLogMessage: string | AgLogMessage): void => {
       // Use info level as default for generic logger function
       this.info(formattedLogMessage);
     };
@@ -145,21 +145,21 @@ export class MockLogger {
   createLoggerMap(): AgLoggerMap {
     return {
       [AG_LOGLEVEL.OFF]: () => {}, // No-op for OFF level
-      [AG_LOGLEVEL.FATAL]: (message: string) => this.fatal(message),
-      [AG_LOGLEVEL.ERROR]: (message: string) => this.error(message),
-      [AG_LOGLEVEL.WARN]: (message: string) => this.warn(message),
-      [AG_LOGLEVEL.INFO]: (message: string) => this.info(message),
-      [AG_LOGLEVEL.DEBUG]: (message: string) => this.debug(message),
-      [AG_LOGLEVEL.TRACE]: (message: string) => this.trace(message),
+      [AG_LOGLEVEL.FATAL]: (message: string | AgLogMessage) => this.fatal(message),
+      [AG_LOGLEVEL.ERROR]: (message: string | AgLogMessage) => this.error(message),
+      [AG_LOGLEVEL.WARN]: (message: string | AgLogMessage) => this.warn(message),
+      [AG_LOGLEVEL.INFO]: (message: string | AgLogMessage) => this.info(message),
+      [AG_LOGLEVEL.DEBUG]: (message: string | AgLogMessage) => this.debug(message),
+      [AG_LOGLEVEL.TRACE]: (message: string | AgLogMessage) => this.trace(message),
     };
   }
 
   // Legacy methods for backward compatibility
-  getErrorMessages(): string[] {
+  getErrorMessages(): (AgLogMessage | string)[] {
     return this.getMessages(AG_LOGLEVEL.ERROR);
   }
 
-  getLastErrorMessage(): string | null {
+  getLastErrorMessage(): AgLogMessage | string | null {
     return this.getLastMessage(AG_LOGLEVEL.ERROR);
   }
 

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/__tests__/E2eMockLogger.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/__tests__/E2eMockLogger.spec.ts
@@ -51,7 +51,7 @@ describe('E2eMockLogger', () => {
       mockLogger.error('First error');
       mockLogger.error('Second error');
 
-      const errorMessages = mockLogger.getErrorMessages();
+      const errorMessages = mockLogger.getMessages(AG_LOGLEVEL.ERROR);
       expect(errorMessages).toEqual(['First error', 'Second error']);
     });
   });
@@ -64,7 +64,7 @@ describe('E2eMockLogger', () => {
       mockLogger.error('First error');
       mockLogger.error('Second error');
 
-      const lastError = mockLogger.getLastErrorMessage();
+      const lastError = mockLogger.getLastMessage(AG_LOGLEVEL.ERROR);
       expect(lastError).toBe('Second error');
     });
 
@@ -72,7 +72,7 @@ describe('E2eMockLogger', () => {
       mockLogger.startTest(ctx.task.id);
       ctx.onTestFinished(() => mockLogger.endTest());
 
-      const lastError = mockLogger.getLastErrorMessage();
+      const lastError = mockLogger.getLastMessage(AG_LOGLEVEL.ERROR);
       expect(lastError).toBeNull();
     });
   });
@@ -85,11 +85,11 @@ describe('E2eMockLogger', () => {
       mockLogger.error('First error');
       mockLogger.error('Second error');
 
-      mockLogger.clearErrorMessages();
+      mockLogger.clearMessages(AG_LOGLEVEL.ERROR);
 
-      const errorMessages = mockLogger.getErrorMessages();
+      const errorMessages = mockLogger.getMessages(AG_LOGLEVEL.ERROR);
       expect(errorMessages).toEqual([]);
-      expect(mockLogger.getLastErrorMessage()).toBeNull();
+      expect(mockLogger.getLastMessage(AG_LOGLEVEL.ERROR)).toBeNull();
     });
   });
 

--- a/packages/@agla-utils/ag-logger/src/utils/AgLogLevelHelpers.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/AgLogLevelHelpers.ts
@@ -12,12 +12,11 @@ import type { AgLogLevel, AgLogLevelLabel } from '../../shared/types';
 /**
  * Convert numeric log level to string label
  * @param level - Numeric log level
- * @returns String label for the log level
- * @throws Error if log level is invalid
+ * @returns String label for the log level, or empty string if invalid
  */
 export const AgToLabel = (level: AgLogLevel): AgLogLevelLabel => {
-  if (typeof level !== 'number' || level < AG_LOGLEVEL.OFF || level > AG_LOGLEVEL.TRACE || !Number.isInteger(level)) {
-    throw new Error(`Invalid log level: ${level}`);
+  if (!isValidLogLevel(level)) {
+    return '' as AgLogLevelLabel;
   }
 
   return AG_LOGLEVEL_TO_LABEL_MAP[level];
@@ -30,4 +29,11 @@ export const AgToLabel = (level: AgLogLevel): AgLogLevelLabel => {
  */
 export const AgToLogLevel = (level: AgLogLevel): AgLogLevel => {
   return level;
+};
+
+export const isValidLogLevel = (logLevel: AgLogLevel): boolean => {
+  return (
+    typeof logLevel === 'number'
+    && Object.values(AG_LOGLEVEL).includes(logLevel)
+  );
 };

--- a/packages/@agla-utils/ag-logger/src/utils/__tests__/AgLogLevelHelpers.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/__tests__/AgLogLevelHelpers.spec.ts
@@ -11,7 +11,7 @@ import { describe, expect, it } from 'vitest';
 // Import helper functions
 import { AG_LOGLEVEL } from '../../../shared/types';
 import type { AgLogLevel } from '../../../shared/types';
-import { AgToLabel } from '../AgLogLevelHelpers';
+import { AgToLabel, isValidLogLevel } from '../AgLogLevelHelpers';
 
 describe('LogLevel Helper Functions', () => {
   describe('AgToLabel function', () => {
@@ -23,25 +23,14 @@ describe('LogLevel Helper Functions', () => {
       expect(AgToLabel(AG_LOGLEVEL.INFO)).toBe('INFO');
       expect(AgToLabel(AG_LOGLEVEL.DEBUG)).toBe('DEBUG');
       expect(AgToLabel(AG_LOGLEVEL.TRACE)).toBe('TRACE');
+      expect(AgToLabel(AG_LOGLEVEL.VERBOSE)).toBe('VERBOSE');
     });
 
-    it('should maintain compatibility with expected string format', () => {
-      // Test that labels match expected format
-      expect(AgToLabel(AG_LOGLEVEL.OFF)).toBe('OFF');
-      expect(AgToLabel(AG_LOGLEVEL.FATAL)).toBe('FATAL');
-      expect(AgToLabel(AG_LOGLEVEL.ERROR)).toBe('ERROR');
-      expect(AgToLabel(AG_LOGLEVEL.WARN)).toBe('WARN');
-      expect(AgToLabel(AG_LOGLEVEL.INFO)).toBe('INFO');
-      expect(AgToLabel(AG_LOGLEVEL.DEBUG)).toBe('DEBUG');
-      expect(AgToLabel(AG_LOGLEVEL.TRACE)).toBe('TRACE');
-    });
-
-    it('should handle invalid log levels gracefully', () => {
-      // These should either throw or return a sensible default
-      expect(() => AgToLabel(-1 as AgLogLevel)).toThrow('Invalid log level: -1');
-      expect(() => AgToLabel(99 as AgLogLevel)).toThrow('Invalid log level: 99');
-      expect(() => AgToLabel(null as unknown as AgLogLevel)).toThrow('Invalid log level: null');
-      expect(() => AgToLabel(undefined as unknown as AgLogLevel)).toThrow('Invalid log level: undefined');
+    it("should return '' for invalid log levels", () => {
+      expect(AgToLabel(-1 as AgLogLevel)).toBe('');
+      expect(AgToLabel(99 as AgLogLevel)).toBe('');
+      expect(AgToLabel(null as unknown as AgLogLevel)).toBe('');
+      expect(AgToLabel(undefined as unknown as AgLogLevel)).toBe('');
     });
 
     it('should return consistent format', () => {
@@ -74,6 +63,197 @@ describe('LogLevel Helper Functions', () => {
 
       // Should complete in reasonable time (less than 100ms for 1000 operations)
       expect(duration).toBeLessThan(100);
+    });
+  });
+
+  describe('isValidLogLevel function', () => {
+    describe('正常系 (Valid cases)', () => {
+      it('should return true for all valid AG_LOGLEVEL values', () => {
+        expect(isValidLogLevel(AG_LOGLEVEL.VERBOSE)).toBe(true);
+        expect(isValidLogLevel(AG_LOGLEVEL.OFF)).toBe(true);
+        expect(isValidLogLevel(AG_LOGLEVEL.FATAL)).toBe(true);
+        expect(isValidLogLevel(AG_LOGLEVEL.ERROR)).toBe(true);
+        expect(isValidLogLevel(AG_LOGLEVEL.WARN)).toBe(true);
+        expect(isValidLogLevel(AG_LOGLEVEL.INFO)).toBe(true);
+        expect(isValidLogLevel(AG_LOGLEVEL.DEBUG)).toBe(true);
+        expect(isValidLogLevel(AG_LOGLEVEL.TRACE)).toBe(true);
+      });
+
+      it('should return true for numeric literals matching AG_LOGLEVEL values', () => {
+        expect(isValidLogLevel(-99 as AgLogLevel)).toBe(true); // VERBOSE
+        expect(isValidLogLevel(0 as AgLogLevel)).toBe(true); // OFF
+        expect(isValidLogLevel(1 as AgLogLevel)).toBe(true); // FATAL
+        expect(isValidLogLevel(2 as AgLogLevel)).toBe(true); // ERROR
+        expect(isValidLogLevel(3 as AgLogLevel)).toBe(true); // WARN
+        expect(isValidLogLevel(4 as AgLogLevel)).toBe(true); // INFO
+        expect(isValidLogLevel(5 as AgLogLevel)).toBe(true); // DEBUG
+        expect(isValidLogLevel(6 as AgLogLevel)).toBe(true); // TRACE
+      });
+
+      it('should validate all AG_LOGLEVEL values using Object.values iteration', () => {
+        Object.values(AG_LOGLEVEL).forEach((level) => {
+          expect(isValidLogLevel(level)).toBe(true);
+        });
+      });
+    });
+
+    describe('異常系 (Invalid type cases)', () => {
+      it('should return false for undefined', () => {
+        expect(isValidLogLevel(undefined as unknown as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for null', () => {
+        expect(isValidLogLevel(null as unknown as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for string values', () => {
+        expect(isValidLogLevel('0' as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel('1' as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel('INFO' as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel('DEBUG' as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel('' as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel('invalid' as unknown as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for boolean values', () => {
+        expect(isValidLogLevel(true as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(false as unknown as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for object values', () => {
+        expect(isValidLogLevel({} as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel({ level: 1 } as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(AG_LOGLEVEL as unknown as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for array values', () => {
+        expect(isValidLogLevel([] as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel([1] as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel([AG_LOGLEVEL.INFO] as unknown as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for function values', () => {
+        expect(isValidLogLevel((() => 1) as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(isValidLogLevel as unknown as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for symbol values', () => {
+        expect(isValidLogLevel(Symbol('test') as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(Symbol.for('level') as unknown as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for bigint values', () => {
+        expect(isValidLogLevel(1n as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(BigInt(4) as unknown as AgLogLevel)).toBe(false);
+      });
+    });
+
+    describe('エッジケース (Edge cases with numbers)', () => {
+      it('should return false for out-of-range negative numbers', () => {
+        expect(isValidLogLevel(-1 as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(-98 as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(-100 as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(-1000 as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for out-of-range positive numbers', () => {
+        expect(isValidLogLevel(7 as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(8 as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(99 as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(1000 as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for decimal numbers', () => {
+        expect(isValidLogLevel(0.5 as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(1.1 as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(3.14 as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(-99.5 as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for special numeric values', () => {
+        expect(isValidLogLevel(NaN as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(Infinity as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(-Infinity as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for Number object instances', () => {
+        expect(isValidLogLevel(new Number(1) as unknown as AgLogLevel)).toBe(false);
+        expect(isValidLogLevel(new Number(AG_LOGLEVEL.INFO) as unknown as AgLogLevel)).toBe(false);
+      });
+
+      it('should return false for zero variants that are not exactly 0', () => {
+        expect(isValidLogLevel(-0 as AgLogLevel)).toBe(true); // -0 === 0, so this should be true
+        expect(isValidLogLevel(0.0 as AgLogLevel)).toBe(true); // 0.0 === 0, so this should be true
+        expect(isValidLogLevel(Number('0') as AgLogLevel)).toBe(true); // Number('0') === 0
+      });
+    });
+
+    describe('パフォーマンステスト (Performance tests)', () => {
+      it('should validate many values efficiently', () => {
+        const startTime = Date.now();
+        const testValues = [
+          AG_LOGLEVEL.INFO,
+          AG_LOGLEVEL.ERROR,
+          'invalid',
+          null,
+          undefined,
+          7,
+          -1,
+          NaN,
+          {},
+          [],
+        ];
+
+        for (let i = 0; i < 1000; i++) {
+          testValues.forEach((value) => {
+            isValidLogLevel(value as AgLogLevel);
+          });
+        }
+
+        const endTime = Date.now();
+        const duration = endTime - startTime;
+
+        expect(duration).toBeLessThan(100);
+      });
+    });
+
+    describe('型安全性テスト (Type safety with comprehensive edge cases)', () => {
+      it('should handle mixed array of different types', () => {
+        const mixedValues = [
+          1,
+          '1',
+          true,
+          null,
+          undefined,
+          {},
+          [],
+          AG_LOGLEVEL.INFO,
+          Symbol('test'),
+          1n,
+          NaN,
+          Infinity,
+        ];
+
+        mixedValues.forEach((value) => {
+          const result = isValidLogLevel(value as AgLogLevel);
+          expect(typeof result).toBe('boolean');
+        });
+      });
+
+      it('should maintain consistent behavior across multiple calls', () => {
+        const testCases = [
+          { value: AG_LOGLEVEL.INFO, expected: true },
+          { value: 'INFO' as unknown as AgLogLevel, expected: false },
+          { value: 7 as AgLogLevel, expected: false },
+          { value: null as unknown as AgLogLevel, expected: false },
+        ];
+
+        testCases.forEach(({ value, expected }) => {
+          for (let i = 0; i < 10; i++) {
+            expect(isValidLogLevel(value)).toBe(expected);
+          }
+        });
+      });
     });
   });
 });

--- a/packages/@agla-utils/ag-logger/tests/e2e/E2EMockLogger.e2e.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/e2e/E2EMockLogger.e2e.spec.ts
@@ -11,6 +11,7 @@ import { PlainFormatter } from '@/plugins/formatter/PlainFormatter';
 import { E2eMockLogger as E2EMockLoggerWithTestId } from '@/plugins/logger/E2eMockLogger';
 import { describe, expect, it } from 'vitest';
 import { AG_LOGLEVEL } from '../../shared/types';
+import type { AgFormattedLogMessage } from '../../shared/types';
 
 /**
  * E2EMockLoggerWithTestId E2Eテストスイート
@@ -254,7 +255,7 @@ describe('E2EMockLoggerWithTestId', () => {
   const simulateParallelTest = async function(
     identifier: string,
     message: string,
-  ): Promise<{ testId: string; messages: string[] }> {
+  ): Promise<{ testId: string; messages: AgFormattedLogMessage[] }> {
     const parallelMockLogger = new E2EMockLoggerWithTestId(identifier);
     const testId = `${identifier}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 


### PR DESCRIPTION
## Overview

This Pull Request introduces support for the special `VERBOSE` log level, adds a `MockFormatter` utility for consistent log formatting in tests, and improves logger type safety throughout the `ag-logger` package.

It improves internal flexibility, test clarity, and developer experience when dealing with log message structure and formatting behavior.

## Changes

- [x] Added/updated files or modules  
- [x] Removed deprecated logic or configs  
- [x] Refactored for clarity/performance  
- [x] Other (see below)

## Key Additions

- `VERBOSE` level added to `AG_LOGLEVEL`, handled by `console.debug` in `ConsoleLogger`
- `MockLogger` and `E2eMockLogger` now fully support `VERBOSE`
- `executeLog()` made testable via visibility change; internal logging unified
- `AG_LOGLEVEL_KEYS` and `AgLogLevelKey` added for safer level validation
- **New `MockFormatter` plugin** introduced for precise and reusable test formatting
- Extended logger/formatter function types to support structured `AgLogMessage` objects

## Related Issues

> None directly. This PR lays the groundwork for more robust log validation and plugin isolation in future improvements.

## Checklist

- [x] Lint checks pass (`pnpm lint`)  
- [x] Tests pass (`pnpm test`)  
- [ ] Documentation is updated (if applicable)  
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)  
- [ ] Descriptions and examples are clear

## Additional Notes

- `MockFormatter` uses consistent formatting logic for JSON, string passthrough, and structured messages.
- Type improvements ensure logger and formatter functions can reliably accept or return `AgLogMessage` types.
- Tests were enhanced to verify behavior across log levels, formatting variants, and fallback edge cases.
