### PR TITLE
test(ag-logger): standardize logger function usage across test suites

### DIFF
--- a/packages/@agla-utils/ag-logger/src/utils/AgLogHelpers.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/AgLogHelpers.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 import { AG_LABEL_TO_LOGLEVEL_MAP, AG_LOGLEVEL, AG_LOGLEVEL_TO_LABEL_MAP } from '../../shared/types';
-import type { AgLogLevel, AgLogLevelLabel } from '../../shared/types';
+import type { AgFormattedLogMessage, AgLoggerFunction, AgLogLevel, AgLogLevelLabel } from '../../shared/types';
 import { isValidLogLevel } from './AgLogValidators';
 
 /**
@@ -103,4 +103,33 @@ export const argsToString = (args: readonly unknown[]): string => {
 
   const message = args.map((arg) => JSON.stringify(arg) || valueToString(arg)).join(' ').trim();
   return message;
+};
+
+/**
+ * Creates a logger function that can be registered in loggerMap.
+ * Takes a module function and returns a function compatible with AgLoggerFunction.
+ *
+ * @param moduleFunc - The function to wrap (e.g., this.executeLog, this.debug, console.error)
+ * @returns A function that takes logLevel and message and calls the module function
+ *
+ * @example
+ * ```typescript
+ * // For this.executeLog(level, message)
+ * const loggerFunc = createLoggerFunction((level, message) => this.executeLog(level, message));
+ *
+ * // For this.debug(message)
+ * const debugFunc = createLoggerFunction((level, message) => this.debug(message));
+ *
+ * // For console.error(formattedMessage)
+ * const consoleFunc = createLoggerFunction((level, message) => console.error(message));
+ * ```
+ */
+export const createLoggerFunction = (
+  moduleFunc: (level: AgLogLevel, message: AgFormattedLogMessage) => void,
+): AgLoggerFunction => {
+  return (formattedMessage: AgFormattedLogMessage): void => {
+    // Extract level information if available, otherwise use a default level
+    // Since we only have the formatted message, we'll pass a default level
+    moduleFunc(AG_LOGLEVEL.INFO, formattedMessage);
+  };
 };

--- a/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/createLoggerFunction.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/createLoggerFunction.spec.ts
@@ -1,0 +1,71 @@
+// src/utils/__tests__/agLogHelpers/createLoggerFunction.spec.ts
+// @(#) : BDD Tests for createLoggerFunction utility
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AG_LOGLEVEL } from '../../../../shared/types';
+import { AgMockBufferLogger } from '../../../plugins/logger/MockLogger';
+import { createLoggerFunction } from '../../AgLogHelpers';
+
+describe('createLoggerFunction', () => {
+  let mockLogger: AgMockBufferLogger;
+  let loggerFunc: ReturnType<typeof createLoggerFunction>;
+
+  beforeEach(() => {
+    mockLogger = new AgMockBufferLogger();
+    loggerFunc = createLoggerFunction((level, message) => mockLogger.executeLog(level, message));
+  });
+
+  describe('When creating logger functions for loggerMap registration', () => {
+    it('should create a function compatible with AgLoggerFunction interface', () => {
+      expect(typeof loggerFunc).toBe('function');
+      expect(loggerFunc.length).toBe(1);
+    });
+
+    it('should call executeLog with default INFO level and provided message', () => {
+      loggerFunc('test message');
+
+      const messages = mockLogger.getMessages(AG_LOGLEVEL.INFO);
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toBe('test message');
+    });
+  });
+
+  describe('When handling different message types', () => {
+    it('should handle string messages', () => {
+      loggerFunc('string message');
+
+      expect(mockLogger.getMessages(AG_LOGLEVEL.INFO)).toContain('string message');
+    });
+
+    it('should handle AgLogMessage objects', () => {
+      const logMessage = {
+        logLevel: AG_LOGLEVEL.ERROR,
+        timestamp: new Date(),
+        message: 'error message',
+        args: [],
+      };
+
+      loggerFunc(logMessage);
+
+      expect(mockLogger.getMessages(AG_LOGLEVEL.INFO)).toContain(logMessage);
+    });
+
+    it('should handle empty string messages', () => {
+      loggerFunc('');
+
+      expect(mockLogger.getMessages(AG_LOGLEVEL.INFO)).toContain('');
+    });
+  });
+
+  describe('When handling multiple calls', () => {
+    it('should handle successive calls correctly', () => {
+      loggerFunc('first message');
+      loggerFunc('second message');
+      loggerFunc('third message');
+
+      const messages = mockLogger.getMessages(AG_LOGLEVEL.INFO);
+      expect(messages).toHaveLength(3);
+      expect(messages).toEqual(['first message', 'second message', 'third message']);
+    });
+  });
+});

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/basic.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/basic.integration.spec.ts
@@ -100,7 +100,7 @@ describe('AgLogger Basic Integration Tests', () => {
 
         // ロガーマネージャー設定の共有
         logger1.setLoggerConfig({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: JsonFormatter,
         });
 

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/configuration.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/configuration.integration.spec.ts
@@ -73,11 +73,11 @@ describe('AgLogger Configuration Integration Tests', () => {
         const defaultLogger = new MockLogger.buffer();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: defaultLogger.createLoggerFunction(),
+          defaultLogger: defaultLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: MockFormatter.passthrough,
           loggerMap: {
-            [AG_LOGLEVEL.ERROR]: errorLogger.createLoggerFunction(AG_LOGLEVEL.ERROR),
-            [AG_LOGLEVEL.WARN]: warnLogger.createLoggerFunction(AG_LOGLEVEL.WARN),
+            [AG_LOGLEVEL.ERROR]: errorLogger.getLoggerFunction(AG_LOGLEVEL.ERROR),
+            [AG_LOGLEVEL.WARN]: warnLogger.getLoggerFunction(AG_LOGLEVEL.WARN),
           },
         });
 
@@ -113,12 +113,12 @@ describe('AgLogger Configuration Integration Tests', () => {
         const tempLogger1 = new MockLogger.buffer();
         const tempLogger2 = new MockLogger.buffer();
 
-        logger.setLoggerConfig({ defaultLogger: tempLogger1.createLoggerFunction() });
+        logger.setLoggerConfig({ defaultLogger: tempLogger1.getLoggerFunction(AG_LOGLEVEL.INFO) });
         logger.setLoggerConfig({
-          loggerMap: { [AG_LOGLEVEL.ERROR]: tempLogger2.createLoggerFunction(AG_LOGLEVEL.ERROR) },
+          loggerMap: { [AG_LOGLEVEL.ERROR]: tempLogger2.getLoggerFunction(AG_LOGLEVEL.ERROR) },
         });
         logger.setLoggerConfig({ formatter: MockFormatter.json });
-        logger.setLoggerConfig({ defaultLogger: finalLogger.createLoggerFunction() });
+        logger.setLoggerConfig({ defaultLogger: finalLogger.getLoggerFunction(AG_LOGLEVEL.INFO) });
 
         logger.logLevel = AG_LOGLEVEL.INFO;
         logger.info('test message');

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/dataProcessing.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/dataProcessing.integration.spec.ts
@@ -90,7 +90,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         setupTestContext();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: vi.fn().mockImplementation((logMessage) => {
             // フォーマッターで循環参照を処理するシナリオ
             try {
@@ -127,7 +127,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: errorHandlingFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;
@@ -169,7 +169,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: resilientFormatter,
           loggerMap: mockLogger.defaultLoggerMap,
         });
@@ -235,7 +235,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: safeFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;
@@ -291,7 +291,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: circularSafeFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/edgecases.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/edgecases.integration.spec.ts
@@ -65,7 +65,7 @@ describe('AgLogger Complex Edge Cases Integration Tests', () => {
     it('should handle deeply nested objects', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -90,7 +90,7 @@ describe('AgLogger Complex Edge Cases Integration Tests', () => {
     it('should handle errors with custom properties', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -113,7 +113,7 @@ describe('AgLogger Complex Edge Cases Integration Tests', () => {
     it('should handle multiple error types simultaneously', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -137,7 +137,7 @@ describe('AgLogger Complex Edge Cases Integration Tests', () => {
     it('should handle various whitespace types consistently', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/filtering.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/filtering.integration.spec.ts
@@ -99,7 +99,7 @@ describe('AgLogger Filtering Integration Tests', () => {
         setupTestContext();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: mockFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.OFF;
@@ -193,7 +193,7 @@ describe('AgLogger Filtering Integration Tests', () => {
         setupTestContext();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: MockFormatter.messageOnly,
           loggerMap: mockLogger.defaultLoggerMap,
         });
@@ -243,7 +243,7 @@ describe('AgLogger Filtering Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: throwingFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;
@@ -263,7 +263,7 @@ describe('AgLogger Filtering Integration Tests', () => {
         setupTestContext();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: PlainFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/performance.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/performance.integration.spec.ts
@@ -58,7 +58,7 @@ describe('AgLogger Performance Integration Tests', () => {
 
       const mockFormatter = vi.fn().mockImplementation((msg) => msg.message ?? msg);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -114,7 +114,7 @@ describe('AgLogger Performance Integration Tests', () => {
       const { mockLogger } = createMock(ctx);
       const mockFormatter = vi.fn().mockImplementation((msg) => msg.message ?? msg);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
 
@@ -138,7 +138,7 @@ describe('AgLogger Performance Integration Tests', () => {
       const { mockLogger } = createMock(ctx);
       const mockFormatter = vi.fn().mockImplementation((msg) => msg.message ?? msg);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
         loggerMap: mockLogger.defaultLoggerMap,
       });
@@ -164,7 +164,7 @@ describe('AgLogger Performance Integration Tests', () => {
       const { mockLogger } = createMock(ctx);
       // Setup
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
         loggerMap: mockLogger.defaultLoggerMap,
       });
@@ -195,7 +195,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should handle very long messages', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -210,7 +210,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should handle large number of arguments', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -225,7 +225,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should handle large objects in arguments', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -249,7 +249,7 @@ describe('AgLogger Performance Integration Tests', () => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       for (let i = 0; i < 50; i++) {
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.createLoggerFunction(),
+          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
           formatter: mockFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;
@@ -264,7 +264,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should maintain state consistency under stress', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
 
@@ -289,7 +289,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should maintain consistency with rapid state changes and complex data', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
         loggerMap: mockLogger.createLoggerMap(),
       });
@@ -328,7 +328,7 @@ describe('AgLogger Performance Integration Tests', () => {
       });
 
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: stressFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -351,7 +351,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should handle Unicode characters in high-volume processing', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.createLoggerFunction(),
+        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;


### PR DESCRIPTION
## ✨ Overview

This PR updates the ag-logger test suites to ensure consistent and maintainable logger function usage across all test categories.  
The changes replace ad-hoc logger initialization patterns with standardized helper functions, improving readability and reducing duplication.

---

## 🔧 Changes

- Updated tests to read `defaultFunction` from `loggerMap` instead of using a single logger function.
- Standardized INFO-level logger function usage in `E2EMockLogger` tests.
- Replaced `createLoggerMap` with `getLoggerFunction` for consistent logger retrieval in integration tests.
- Refactored logger initialization in test suites to use `createLoggerFunction`.

---

## 📂 Related Issues

> Related to internal test consistency and maintainability improvements.

---

## ✅ Checklist

- [x] Lint checks pass (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## 💬 Additional Notes

These changes align all tests with the new `createLoggerFunction` and `getLoggerFunction` helpers introduced in recent refactoring, ensuring future logger-related changes are easier to propagate.
