### PR TITLE
feat(logger):  add DEFAULT to LogLevel & change FORCE_OUTPUT to LOG

### DIFF
--- a/packages/@agla-utils/ag-logger/shared/types/AgLogLevel.types.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgLogLevel.types.ts
@@ -35,12 +35,12 @@ export const AG_LOGLEVEL = {
   /** Very detailed tracing information. */
   TRACE: 6,
   // special level
-  /** special level: force output mode */
-  LOG: -12,
-  /** Special level: emits even if filters would suppress (history suggests -98). */
-  FORCE_OUTPUT: -98,
   /** special level: verbose mode */
-  VERBOSE: -99,
+  VERBOSE: -11,
+  /** special level: LOG output (force output) */
+  LOG: -12,
+  /** Special level: default (defaultLogger: LogLevel  is same for INFO) */
+  DEFAULT: -99,
 } as const;
 
 /**

--- a/packages/@agla-utils/ag-logger/shared/types/AgLogLevel.types.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgLogLevel.types.ts
@@ -34,67 +34,14 @@ export const AG_LOGLEVEL = {
   DEBUG: 5,
   /** Very detailed tracing information. */
   TRACE: 6,
-  /** special value: force output mode */
+  // special level
+  /** special level: force output mode */
+  LOG: -12,
+  /** Special level: emits even if filters would suppress (history suggests -98). */
   FORCE_OUTPUT: -98,
-  /** special value: verbose mode  */
+  /** special level: verbose mode */
   VERBOSE: -99,
 } as const;
-
-/**
- * Label to numeric log level conversion map.
- * Used for configuration file integration and string-to-numeric conversion.
- *
- * @example
- * ```typescript
- * const level = AG_LABEL_TO_LOGLEVEL_MAP['INFO']; // Returns 4
- * ```
- */
-export const AG_LABEL_TO_LOGLEVEL_MAP = {
-  /** Maps 'OFF' string to numeric value 0. */
-  'OFF': AG_LOGLEVEL.OFF,
-  /** Maps 'FATAL' string to numeric value 1. */
-  'FATAL': AG_LOGLEVEL.FATAL,
-  /** Maps 'ERROR' string to numeric value 2. */
-  'ERROR': AG_LOGLEVEL.ERROR,
-  /** Maps 'WARN' string to numeric value 3. */
-  'WARN': AG_LOGLEVEL.WARN,
-  /** Maps 'INFO' string to numeric value 4. */
-  'INFO': AG_LOGLEVEL.INFO,
-  /** Maps 'DEBUG' string to numeric value 5. */
-  'DEBUG': AG_LOGLEVEL.DEBUG,
-  /** Maps 'TRACE' string to numeric value 6. */
-  'TRACE': AG_LOGLEVEL.TRACE,
-  // -- special values
-  /** Maps 'FORCE_OUTPUT' string to numeric value -98. */
-  'FORCE_OUTPUT': AG_LOGLEVEL.FORCE_OUTPUT,
-  /** Maps 'VERBOSE' string to numeric value -99. */
-  'VERBOSE': AG_LOGLEVEL.VERBOSE,
-} as const;
-
-/**
- * Numeric to label log level conversion map (auto-generated).
- * Used for numeric-to-string conversion in formatters and utilities.
- *
- * @example
- * ```typescript
- * const label = AG_LOGLEVEL_TO_LABEL_MAP[4]; // Returns 'INFO'
- * ```
- */
-export const AG_LOGLEVEL_TO_LABEL_MAP = Object.fromEntries(
-  Object.entries(AG_LABEL_TO_LOGLEVEL_MAP).map(([key, value]) => [value, key]),
-) as Record<AgLogLevel, AgLogLevelLabel>;
-
-/**
- * Numeric log level type derived from AG_LOGLEVEL values.
- * Represents all valid numeric log level values (0-6).
- *
- * @example
- * ```typescript
- * const level: AgLogLevel = AG_LOGLEVEL.INFO; // Valid
- * const invalid: AgLogLevel = 7; // Type error
- * ```
- */
-export type AgLogLevel = typeof AG_LOGLEVEL[keyof typeof AG_LOGLEVEL];
 
 /**
  * String log level label type derived from AG_LABEL_TO_LOGLEVEL_MAP keys.
@@ -106,27 +53,48 @@ export type AgLogLevel = typeof AG_LOGLEVEL[keyof typeof AG_LOGLEVEL];
  * const invalid: AgLogLevelLabel = 'INVALID'; // Type error
  * ```
  */
-export type AgLogLevelLabel = keyof typeof AG_LABEL_TO_LOGLEVEL_MAP;
+export type AgLogLevel = typeof AG_LOGLEVEL[keyof typeof AG_LOGLEVEL];
+
+export const AG_LOGLEVEL_VALUES = Object.values(AG_LOGLEVEL) as AgLogLevel[];
 
 /**
- * Log level key type derived from AG_LOGLEVEL keys.
- * Represents all valid log level constant names.
+ * String log level label type derived from AG_LABEL_TO_LOGLEVEL_MAP keys.
+ * Represents all valid string log level labels.
  *
  * @example
  * ```typescript
- * const key: AgLogLevelKey = 'INFO'; // Valid
- * const invalid: AgLogLevelKey = 'INVALID'; // Type error
+ * const label: AgLogLevelLabel = 'INFO'; // Valid
+ * const invalid: AgLogLevelLabel = 'INVALID'; // Type error
  * ```
  */
-export type AgLogLevelKey = keyof typeof AG_LOGLEVEL;
+export type AgLogLevelLabel = keyof typeof AG_LOGLEVEL;
+
+export const AG_LOGLEVEL_KEYS = Object.keys(AG_LOGLEVEL) as AgLogLevelLabel[];
 
 /**
- * Array of all log level keys in AG_LOGLEVEL.
- * Useful for iteration and functional programming operations.
+ * Map of string log level labels to their corresponding numeric log levels.
+ * Used for conversion between string and numeric log levels.
  *
  * @example
  * ```typescript
- * AG_LOGLEVEL_KEYS.forEach(key => console.log(AG_LOGLEVEL[key]));
+ * const logLevel: AgLogLevel = AG_LABEL_TO_LOGLEVEL_MAP['INFO']; // 4
  * ```
  */
-export const AG_LOGLEVEL_KEYS = Object.keys(AG_LOGLEVEL) as AgLogLevelKey[];
+export const AG_LOGLEVEL_TO_LABEL_MAP = Object.fromEntries(
+  (Object.entries(AG_LOGLEVEL) as [AgLogLevelLabel, AgLogLevel][])
+    .map(([label, value]) => [value, label]),
+) as Record<AgLogLevel, AgLogLevelLabel>;
+
+/**
+ * Map of string log level labels to their corresponding numeric log levels.
+ * Used for conversion between string and numeric log levels.
+ *
+ * @example
+ * ```typescript
+ * const logLevel: AgLogLevel = AG_LABEL_TO_LOGLEVEL_MAP['INFO']; // 4
+ * ```
+ */
+export const AG_LABEL_TO_LOGLEVEL_MAP = Object.fromEntries(
+  (Object.entries(AG_LOGLEVEL) as [AgLogLevelLabel, AgLogLevel][])
+    .map(([label, value]) => [label, value]),
+) as Record<AgLogLevelLabel, AgLogLevel>;

--- a/packages/@agla-utils/ag-logger/shared/types/index.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/index.ts
@@ -10,7 +10,7 @@ export { AglaError } from './AglaError.types';
 export { AgLoggerError } from './AgLoggerError.types';
 
 // Constants and enums
-export { AG_LABEL_TO_LOGLEVEL_MAP, AG_LOGLEVEL, AG_LOGLEVEL_KEYS, AG_LOGLEVEL_TO_LABEL_MAP } from './AgLogLevel.types';
+export * from './AgLogLevel.types';
 
 // Types and interfaces
 export type * from './AgLogger.interface';

--- a/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
@@ -267,9 +267,7 @@ export class AgLogger {
 
   /** Verbose log method that only outputs when verbose flag is true. */
   verbose(...args: unknown[]): void {
-    if (this.isVerbose) {
-      this.executeLog(AG_LOGLEVEL.VERBOSE, ...args);
-    }
+    this.executeLog(AG_LOGLEVEL.VERBOSE, ...args);
   }
 
   /**

--- a/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
@@ -260,9 +260,9 @@ export class AgLogger {
     this.executeLog(AG_LOGLEVEL.TRACE, ...args);
   }
 
-  /** General log method that always outputs (FORCE_OUTPUT level). */
+  /** General log method that always outputs (LOG level). */
   log(...args: unknown[]): void {
-    this.executeLog(AG_LOGLEVEL.FORCE_OUTPUT, ...args);
+    this.executeLog(AG_LOGLEVEL.LOG, ...args);
   }
 
   /** Verbose log method that only outputs when verbose flag is true. */

--- a/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.features.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.features.spec.ts
@@ -135,9 +135,9 @@ describe('AgLogger Special Features', () => {
   });
 });
 
-describe('FORCE_OUTPUT Log Level', () => {
+describe('LOG Log Level', () => {
   setupTestEnvironment();
-  describe('正常系: Basic FORCE_OUTPUT functionality', () => {
+  describe('正常系: Basic LOG functionality', () => {
     it('should output when both logLevel is OFF and verbose is false', () => {
       const logger = AgLogger.createLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.logLevel = AG_LOGLEVEL.OFF;
@@ -181,8 +181,8 @@ describe('FORCE_OUTPUT Log Level', () => {
     });
   });
 
-  describe('異常系: FORCE_OUTPUT error scenarios', () => {
-    it('should handle FORCE_OUTPUT with throwing logger', () => {
+  describe('異常系: LOG error scenarios', () => {
+    it('should handle LOG with throwing logger', () => {
       const throwingLogger = vi.fn(() => {
         throw new Error('Logger error');
       });
@@ -192,7 +192,7 @@ describe('FORCE_OUTPUT Log Level', () => {
       expect(() => logger.log('force output')).toThrow('Logger error');
     });
 
-    it('should handle FORCE_OUTPUT with throwing formatter', () => {
+    it('should handle LOG with throwing formatter', () => {
       const throwingFormatter = vi.fn(() => {
         throw new Error('Formatter error');
       });
@@ -203,8 +203,8 @@ describe('FORCE_OUTPUT Log Level', () => {
     });
   });
 
-  describe('エッジケース: FORCE_OUTPUT edge cases', () => {
-    it('should handle FORCE_OUTPUT with empty message', () => {
+  describe('エッジケース: LOG edge cases', () => {
+    it('should handle LOG with empty message', () => {
       const logger = AgLogger.createLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.logLevel = AG_LOGLEVEL.OFF;
 
@@ -213,7 +213,7 @@ describe('FORCE_OUTPUT Log Level', () => {
       expect(mockLogger).not.toHaveBeenCalled(); // Empty messages are suppressed
     });
 
-    it('should handle FORCE_OUTPUT with no arguments', () => {
+    it('should handle LOG with no arguments', () => {
       const logger = AgLogger.createLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.logLevel = AG_LOGLEVEL.OFF;
 
@@ -223,7 +223,7 @@ describe('FORCE_OUTPUT Log Level', () => {
       expect(mockLogger).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle FORCE_OUTPUT with complex objects', () => {
+    it('should handle LOG with complex objects', () => {
       const logger = AgLogger.createLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.logLevel = AG_LOGLEVEL.OFF;
 
@@ -406,7 +406,7 @@ describe('Configuration Management', () => {
         [AG_LOGLEVEL.INFO]: vi.fn(),
         [AG_LOGLEVEL.DEBUG]: vi.fn(),
         [AG_LOGLEVEL.TRACE]: vi.fn(),
-        [AG_LOGLEVEL.FORCE_OUTPUT]: vi.fn(),
+        [AG_LOGLEVEL.LOG]: vi.fn(),
       };
 
       const logger = AgLogger.createLogger({
@@ -430,7 +430,7 @@ describe('Configuration Management', () => {
       expect(loggerMap[AG_LOGLEVEL.INFO]).toHaveBeenCalledTimes(1);
       expect(loggerMap[AG_LOGLEVEL.DEBUG]).toHaveBeenCalledTimes(1);
       expect(loggerMap[AG_LOGLEVEL.TRACE]).toHaveBeenCalledTimes(1);
-      expect(loggerMap[AG_LOGLEVEL.FORCE_OUTPUT]).toHaveBeenCalledTimes(1);
+      expect(loggerMap[AG_LOGLEVEL.LOG]).toHaveBeenCalledTimes(1);
       expect(mockLogger).not.toHaveBeenCalled(); // All mapped, default not used
     });
 

--- a/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.spec.ts
@@ -868,14 +868,14 @@ describe('エッジケース: Special Arguments and Data Processing', () => {
       });
 
       /**
-       * FORCE_OUTPUT Log Level
+       * LOG Log Level
        *
-       * @description BDD tests for FORCE_OUTPUT log level behavior
+       * @description BDD tests for LOG log level behavior
        */
-      describe('FORCE_OUTPUT Log Level', () => {
+      describe('LOG Log Level', () => {
         setupTestEnvironment();
 
-        describe('log method with FORCE_OUTPUT should output regardless of logLevel and verbose settings', () => {
+        describe('log method with LOG should output regardless of logLevel and verbose settings', () => {
           it('should output when both logLevel is OFF and verbose is false', () => {
             const logger = AgLogger.createLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
             logger.logLevel = AG_LOGLEVEL.OFF;

--- a/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.validators.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.validators.spec.ts
@@ -135,12 +135,14 @@ describe('AgLogger Input Validation', () => {
         it('should accept special log levels', () => {
           expect(() => validateLogLevel(AG_LOGLEVEL.VERBOSE)).not.toThrow();
           expect(() => validateLogLevel(AG_LOGLEVEL.LOG)).not.toThrow();
+          expect(() => validateLogLevel(AG_LOGLEVEL.DEFAULT)).not.toThrow();
         });
 
         it('should return the same valid log level value', () => {
           expect(validateLogLevel(AG_LOGLEVEL.INFO)).toBe(AG_LOGLEVEL.INFO);
           expect(validateLogLevel(AG_LOGLEVEL.VERBOSE)).toBe(AG_LOGLEVEL.VERBOSE);
           expect(validateLogLevel(AG_LOGLEVEL.LOG)).toBe(AG_LOGLEVEL.LOG);
+          expect(validateLogLevel(AG_LOGLEVEL.DEFAULT)).toBe(AG_LOGLEVEL.DEFAULT);
         });
       });
 

--- a/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.validators.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/AgLogger.validators.spec.ts
@@ -12,7 +12,6 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { AG_LOGGER_ERROR_MESSAGES, ERROR_TYPES } from '../../shared/constants';
 import { AG_LOGLEVEL } from '../../shared/types';
 
-import { AgLoggerError } from '../../shared/types/AgLoggerError.types';
 // Types
 import type { AgLogLevel, AgLogMessage } from '../../shared/types';
 // Test target
@@ -84,7 +83,7 @@ describe('AgLogger Input Validation', () => {
         const logger = AgLogger.createLogger();
         const invalidOptions = { defaultLogger: undefined };
 
-        expect(() => logger.setLoggerConfig(invalidOptions)).toThrow(AgLoggerError);
+        expect(() => logger.setLoggerConfig(invalidOptions)).toThrow('defaultLogger must be a valid function');
         expect(() => logger.setLoggerConfig(invalidOptions)).toThrow(
           AG_LOGGER_ERROR_MESSAGES[ERROR_TYPES.CONFIG].INVALID_DEFAULT_LOGGER,
         );
@@ -94,7 +93,7 @@ describe('AgLogger Input Validation', () => {
         const logger = AgLogger.createLogger();
         const invalidOptions = { formatter: undefined };
 
-        expect(() => logger.setLoggerConfig(invalidOptions)).toThrow(AgLoggerError);
+        expect(() => logger.setLoggerConfig(invalidOptions)).toThrow('formatter must be a valid function');
         expect(() => logger.setLoggerConfig(invalidOptions)).toThrow(
           AG_LOGGER_ERROR_MESSAGES[ERROR_TYPES.CONFIG].INVALID_FORMATTER,
         );
@@ -135,24 +134,24 @@ describe('AgLogger Input Validation', () => {
 
         it('should accept special log levels', () => {
           expect(() => validateLogLevel(AG_LOGLEVEL.VERBOSE)).not.toThrow();
-          expect(() => validateLogLevel(AG_LOGLEVEL.FORCE_OUTPUT)).not.toThrow();
+          expect(() => validateLogLevel(AG_LOGLEVEL.LOG)).not.toThrow();
         });
 
         it('should return the same valid log level value', () => {
           expect(validateLogLevel(AG_LOGLEVEL.INFO)).toBe(AG_LOGLEVEL.INFO);
           expect(validateLogLevel(AG_LOGLEVEL.VERBOSE)).toBe(AG_LOGLEVEL.VERBOSE);
-          expect(validateLogLevel(AG_LOGLEVEL.FORCE_OUTPUT)).toBe(AG_LOGLEVEL.FORCE_OUTPUT);
+          expect(validateLogLevel(AG_LOGLEVEL.LOG)).toBe(AG_LOGLEVEL.LOG);
         });
       });
 
       describe('Invalid type cases', () => {
         it('should throw AgLoggerError for non-number types', () => {
-          expect(() => validateLogLevel(undefined as unknown as AgLogLevel)).toThrow(AgLoggerError);
-          expect(() => validateLogLevel(null as unknown as AgLogLevel)).toThrow(AgLoggerError);
-          expect(() => validateLogLevel('invalid' as unknown as AgLogLevel)).toThrow(AgLoggerError);
-          expect(() => validateLogLevel(true as unknown as AgLogLevel)).toThrow(AgLoggerError);
-          expect(() => validateLogLevel({} as unknown as AgLogLevel)).toThrow(AgLoggerError);
-          expect(() => validateLogLevel([] as unknown as AgLogLevel)).toThrow(AgLoggerError);
+          expect(() => validateLogLevel(undefined as unknown as AgLogLevel)).toThrow('Invalid log level (undefined)');
+          expect(() => validateLogLevel(null as unknown as AgLogLevel)).toThrow('Invalid log level (null)');
+          expect(() => validateLogLevel('invalid' as unknown as AgLogLevel)).toThrow('Invalid log level ("invalid")');
+          expect(() => validateLogLevel(true as unknown as AgLogLevel)).toThrow('Invalid log level (true)');
+          expect(() => validateLogLevel({} as unknown as AgLogLevel)).toThrow('Invalid log level (object)');
+          expect(() => validateLogLevel([] as unknown as AgLogLevel)).toThrow('Invalid log level (array)');
         });
 
         it('should provide descriptive error messages for invalid types', () => {
@@ -187,8 +186,8 @@ describe('AgLogger Input Validation', () => {
           // Valid boundaries
           expect(validateLogLevel(0)).toBe(AG_LOGLEVEL.OFF);
           expect(validateLogLevel(6)).toBe(AG_LOGLEVEL.TRACE);
-          expect(validateLogLevel(-99)).toBe(AG_LOGLEVEL.VERBOSE);
-          expect(validateLogLevel(-98)).toBe(AG_LOGLEVEL.FORCE_OUTPUT);
+          expect(validateLogLevel(-99)).toBe(AG_LOGLEVEL.DEFAULT);
+          expect(validateLogLevel(-12)).toBe(AG_LOGLEVEL.LOG);
         });
 
         it('should reject values just outside boundaries', () => {
@@ -220,10 +219,10 @@ describe('AgLogger Input Validation', () => {
 
         expect(() => {
           logger.logLevel = 999 as AgLogLevel;
-        }).toThrow(AgLoggerError);
+        }).toThrow('Invalid log level (999)');
         expect(() => {
           logger.logLevel = 'invalid' as unknown as AgLogLevel;
-        }).toThrow(AgLoggerError);
+        }).toThrow('Invalid log level ("invalid")');
       });
     });
 
@@ -249,8 +248,8 @@ describe('AgLogger Input Validation', () => {
         const logger = AgLogger.createLogger() as TestableAgLogger;
         logger.logLevel = AG_LOGLEVEL.OFF;
 
-        // FORCE_OUTPUT should always output
-        expect(logger.shouldOutput(AG_LOGLEVEL.FORCE_OUTPUT)).toBe(true);
+        // LOG should always output
+        expect(logger.shouldOutput(AG_LOGLEVEL.LOG)).toBe(true);
 
         // VERBOSE should be controlled by verbose setting
         logger.setVerbose = true;

--- a/packages/@agla-utils/ag-logger/src/__tests__/aglogger/AgLogger.levels.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/aglogger/AgLogger.levels.spec.ts
@@ -161,8 +161,8 @@ describe('AgLogger Log Level Management', () => {
     });
   });
 
-  describe('FORCE_OUTPUT Special Behavior', () => {
-    it('should output FORCE_OUTPUT regardless of logLevel and verbose settings', () => {
+  describe('LOG Special Behavior', () => {
+    it('should output LOG regardless of logLevel and verbose settings', () => {
       const logger = AgLogger.createLogger({ defaultLogger: mockLogger, formatter: mockFormatter });
       logger.logLevel = AG_LOGLEVEL.OFF;
       logger.setVerbose = DISABLE;

--- a/packages/@agla-utils/ag-logger/src/_types/__tests__/AgLogLevel.types.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/_types/__tests__/AgLogLevel.types.spec.ts
@@ -221,7 +221,7 @@ describe('AgLogLevel Types and Constants Tests', () => {
       expect(AG_LABEL_TO_LOGLEVEL_MAP['DEBUG']).toBe(AG_LOGLEVEL.DEBUG);
       expect(AG_LABEL_TO_LOGLEVEL_MAP['TRACE']).toBe(AG_LOGLEVEL.TRACE);
       expect(AG_LABEL_TO_LOGLEVEL_MAP['LOG']).toBe(AG_LOGLEVEL.LOG);
-      expect(AG_LABEL_TO_LOGLEVEL_MAP['LOG']).toBe(AG_LOGLEVEL.LOG);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['DEFAULT']).toBe(AG_LOGLEVEL.DEFAULT);
       expect(AG_LABEL_TO_LOGLEVEL_MAP['VERBOSE']).toBe(AG_LOGLEVEL.VERBOSE);
     });
 

--- a/packages/@agla-utils/ag-logger/src/_types/__tests__/AgLogLevel.types.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/_types/__tests__/AgLogLevel.types.spec.ts
@@ -1,0 +1,333 @@
+// src: _types/__tests__/AgLogLevel.types.spec.ts
+// @(#): AgLogLevel型定義の包括的テストスイート
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// test framework
+import { describe, expect, it } from 'vitest';
+
+// target types and constants
+import type { AgLogLevel, AgLogLevelLabel } from '../../../shared/types/AgLogLevel.types';
+import {
+  AG_LABEL_TO_LOGLEVEL_MAP,
+  AG_LOGLEVEL,
+  AG_LOGLEVEL_KEYS,
+  AG_LOGLEVEL_TO_LABEL_MAP,
+  AG_LOGLEVEL_VALUES,
+} from '../../../shared/types/AgLogLevel.types';
+
+/**
+ * AgLogLevel型定義の包括的テストスイート
+ *
+ * AgLogLevel関連の型定義、定数、変換マップの包括的な検証を行います。
+ * atsushifx式BDDアプローチに従い、正常系、異常系、エッジケースを含む
+ * 網羅的なテストを実装しています。
+ *
+ * @remarks
+ * テストカバレッジ:
+ * - AG_LOGLEVEL定数オブジェクトの構造と値の検証
+ * - AgLogLevel型とAgLogLevelLabel型の型安全性テスト
+ * - 配列・マップの整合性とデータ変換の正確性検証
+ * - 境界値・エッジケースの包括的テスト
+ */
+describe('AgLogLevel Types and Constants Tests', () => {
+  /**
+   * Task 1: AG_LOGLEVEL定数オブジェクトの検証
+   *
+   * AG_LOGLEVELオブジェクトが正しく定義され、期待する値と構造を持つことを検証します。
+   * 標準ログレベルと特殊ログレベルの両方をテストします。
+   */
+  describe('Task 1: AG_LOGLEVEL定数オブジェクトの検証', () => {
+    /**
+     * 補助Task 1.1: 標準ログレベル定数の値が正しく定義されていることをテスト
+     */
+    it('should define standard log level constants with correct numeric values', () => {
+      expect(AG_LOGLEVEL.OFF).toBe(0);
+      expect(AG_LOGLEVEL.FATAL).toBe(1);
+      expect(AG_LOGLEVEL.ERROR).toBe(2);
+      expect(AG_LOGLEVEL.WARN).toBe(3);
+      expect(AG_LOGLEVEL.INFO).toBe(4);
+      expect(AG_LOGLEVEL.DEBUG).toBe(5);
+      expect(AG_LOGLEVEL.TRACE).toBe(6);
+    });
+
+    /**
+     * 補助Task 1.2: 特殊ログレベル定数の値が正しく定義されていることをテスト
+     */
+    it('should define special log level constants with correct negative values', () => {
+      expect(AG_LOGLEVEL.LOG).toBe(-12);
+      expect(AG_LOGLEVEL.FORCE_OUTPUT).toBe(-98);
+      expect(AG_LOGLEVEL.VERBOSE).toBe(-99);
+    });
+
+    /**
+     * 補助Task 1.3: AG_LOGLEVELオブジェクトがconst assertionで型レベル不変であることをテスト
+     */
+    it('should be readonly at type level with const assertion', () => {
+      // const assertionによる型レベル不変性の検証
+      expect(AG_LOGLEVEL).toBeDefined();
+      expect(typeof AG_LOGLEVEL).toBe('object');
+
+      // 値の変更可能性をテスト（ランタイムでは変更可能）
+      const originalValue = AG_LOGLEVEL.OFF;
+      expect(originalValue).toBe(0);
+
+      // プロパティの存在確認
+      expect(Object.hasOwnProperty.call(AG_LOGLEVEL, 'OFF')).toBe(true);
+    });
+  });
+
+  /**
+   * Task 2: AgLogLevel型の型安全性テスト
+   *
+   * AgLogLevel型が適切に定義され、有効な値のみを受け入れることを検証します。
+   */
+  describe('Task 2: AgLogLevel型の型安全性テスト', () => {
+    /**
+     * 補助Task 2.1: 全ての有効なログレベル値でAgLogLevel型が動作することをテスト
+     */
+    it('should accept all valid log level numeric values', () => {
+      const validLogLevels: AgLogLevel[] = [
+        AG_LOGLEVEL.VERBOSE,
+        AG_LOGLEVEL.FORCE_OUTPUT,
+        AG_LOGLEVEL.LOG,
+        AG_LOGLEVEL.OFF,
+        AG_LOGLEVEL.FATAL,
+        AG_LOGLEVEL.ERROR,
+        AG_LOGLEVEL.WARN,
+        AG_LOGLEVEL.INFO,
+        AG_LOGLEVEL.DEBUG,
+        AG_LOGLEVEL.TRACE,
+      ];
+
+      validLogLevels.forEach((level) => {
+        expect(typeof level).toBe('number');
+        expect(AG_LOGLEVEL_VALUES).toContain(level);
+      });
+    });
+
+    /**
+     * 補助Task 2.2: AgLogLevel配列の整合性をテスト
+     */
+    it('should have consistent AG_LOGLEVEL_VALUES array', () => {
+      expect(AG_LOGLEVEL_VALUES).toHaveLength(10);
+      expect(AG_LOGLEVEL_VALUES).toEqual(expect.arrayContaining([
+        -99,
+        -98,
+        -12,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+      ]));
+
+      AG_LOGLEVEL_VALUES.forEach((value) => {
+        expect(typeof value).toBe('number');
+      });
+    });
+  });
+
+  /**
+   * Task 3: AgLogLevelLabel型の型安全性テスト
+   *
+   * AgLogLevelLabel型が適切に定義され、有効なラベル文字列のみを受け入れることを検証します。
+   */
+  describe('Task 3: AgLogLevelLabel型の型安全性テスト', () => {
+    /**
+     * 補助Task 3.1: 全ての有効なラベル文字列でAgLogLevelLabel型が動作することをテスト
+     */
+    it('should accept all valid log level label strings', () => {
+      const validLabels: AgLogLevelLabel[] = [
+        'VERBOSE',
+        'FORCE_OUTPUT',
+        'LOG',
+        'OFF',
+        'FATAL',
+        'ERROR',
+        'WARN',
+        'INFO',
+        'DEBUG',
+        'TRACE',
+      ];
+
+      validLabels.forEach((label) => {
+        expect(typeof label).toBe('string');
+        expect(AG_LOGLEVEL_KEYS).toContain(label);
+        expect(AG_LOGLEVEL).toHaveProperty(label);
+      });
+    });
+
+    /**
+     * 補助Task 3.2: AgLogLevelLabel配列の整合性をテスト
+     */
+    it('should have consistent AG_LOGLEVEL_KEYS array', () => {
+      expect(AG_LOGLEVEL_KEYS).toHaveLength(10);
+      expect(AG_LOGLEVEL_KEYS).toEqual(expect.arrayContaining([
+        'VERBOSE',
+        'FORCE_OUTPUT',
+        'LOG',
+        'OFF',
+        'FATAL',
+        'ERROR',
+        'WARN',
+        'INFO',
+        'DEBUG',
+        'TRACE',
+      ]));
+
+      AG_LOGLEVEL_KEYS.forEach((key) => {
+        expect(typeof key).toBe('string');
+      });
+    });
+  });
+
+  /**
+   * Task 4: 変換マップの整合性テスト
+   *
+   * AG_LOGLEVEL_TO_LABEL_MAPとAG_LABEL_TO_LOGLEVEL_MAPが正しく変換を行うことを検証します。
+   */
+  describe('Task 4: 変換マップの整合性テスト', () => {
+    /**
+     * 補助Task 4.1: ログレベルからラベルへの変換マップが正しく動作することをテスト
+     */
+    it('should convert log levels to labels correctly', () => {
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.OFF]).toBe('OFF');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.FATAL]).toBe('FATAL');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.ERROR]).toBe('ERROR');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.WARN]).toBe('WARN');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.INFO]).toBe('INFO');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.DEBUG]).toBe('DEBUG');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.TRACE]).toBe('TRACE');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.LOG]).toBe('LOG');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.FORCE_OUTPUT]).toBe('FORCE_OUTPUT');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.VERBOSE]).toBe('VERBOSE');
+    });
+
+    /**
+     * 補助Task 4.2: ラベルからログレベルへの変換マップが正しく動作することをテスト
+     */
+    it('should convert labels to log levels correctly', () => {
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['OFF']).toBe(AG_LOGLEVEL.OFF);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['FATAL']).toBe(AG_LOGLEVEL.FATAL);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['ERROR']).toBe(AG_LOGLEVEL.ERROR);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['WARN']).toBe(AG_LOGLEVEL.WARN);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['INFO']).toBe(AG_LOGLEVEL.INFO);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['DEBUG']).toBe(AG_LOGLEVEL.DEBUG);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['TRACE']).toBe(AG_LOGLEVEL.TRACE);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['LOG']).toBe(AG_LOGLEVEL.LOG);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['FORCE_OUTPUT']).toBe(AG_LOGLEVEL.FORCE_OUTPUT);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['VERBOSE']).toBe(AG_LOGLEVEL.VERBOSE);
+    });
+
+    /**
+     * 補助Task 4.3: 双方向変換の一貫性をテスト
+     */
+    it('should maintain bidirectional conversion consistency', () => {
+      AG_LOGLEVEL_VALUES.forEach((level) => {
+        const label = AG_LOGLEVEL_TO_LABEL_MAP[level];
+        expect(AG_LABEL_TO_LOGLEVEL_MAP[label]).toBe(level);
+      });
+
+      AG_LOGLEVEL_KEYS.forEach((label) => {
+        const level = AG_LABEL_TO_LOGLEVEL_MAP[label];
+        expect(AG_LOGLEVEL_TO_LABEL_MAP[level]).toBe(label);
+      });
+    });
+  });
+
+  /**
+   * Task 5: エッジケースと境界値テスト
+   *
+   * ログレベルの境界値やエッジケースでの動作を検証します。
+   */
+  describe('Task 5: エッジケースと境界値テスト', () => {
+    /**
+     * 補助Task 5.1: 最小値・最大値のログレベル境界をテスト
+     */
+    it('should handle minimum and maximum log level boundaries', () => {
+      const minLogLevel = Math.min(...AG_LOGLEVEL_VALUES);
+      const maxLogLevel = Math.max(...AG_LOGLEVEL_VALUES);
+
+      expect(minLogLevel).toBe(AG_LOGLEVEL.VERBOSE);
+      expect(maxLogLevel).toBe(AG_LOGLEVEL.TRACE);
+      expect(minLogLevel).toBeLessThan(maxLogLevel);
+    });
+
+    /**
+     * 補助Task 5.2: ログレベル順序の一貫性をテスト
+     */
+    it('should maintain consistent log level ordering', () => {
+      expect(AG_LOGLEVEL.OFF).toBeLessThan(AG_LOGLEVEL.FATAL);
+      expect(AG_LOGLEVEL.FATAL).toBeLessThan(AG_LOGLEVEL.ERROR);
+      expect(AG_LOGLEVEL.ERROR).toBeLessThan(AG_LOGLEVEL.WARN);
+      expect(AG_LOGLEVEL.WARN).toBeLessThan(AG_LOGLEVEL.INFO);
+      expect(AG_LOGLEVEL.INFO).toBeLessThan(AG_LOGLEVEL.DEBUG);
+      expect(AG_LOGLEVEL.DEBUG).toBeLessThan(AG_LOGLEVEL.TRACE);
+
+      expect(AG_LOGLEVEL.VERBOSE).toBeLessThan(AG_LOGLEVEL.FORCE_OUTPUT);
+      expect(AG_LOGLEVEL.FORCE_OUTPUT).toBeLessThan(AG_LOGLEVEL.LOG);
+      expect(AG_LOGLEVEL.LOG).toBeLessThan(AG_LOGLEVEL.OFF);
+    });
+
+    /**
+     * 補助Task 5.3: 重複値がないことをテスト
+     */
+    it('should have no duplicate log level values', () => {
+      const uniqueValues = [...new Set(AG_LOGLEVEL_VALUES)];
+      expect(uniqueValues).toHaveLength(AG_LOGLEVEL_VALUES.length);
+    });
+
+    /**
+     * 補助Task 5.4: 重複ラベルがないことをテスト
+     */
+    it('should have no duplicate log level labels', () => {
+      const uniqueKeys = [...new Set(AG_LOGLEVEL_KEYS)];
+      expect(uniqueKeys).toHaveLength(AG_LOGLEVEL_KEYS.length);
+    });
+  });
+
+  /**
+   * Task 6: データ構造の整合性テスト
+   *
+   * 全ての関連データ構造が相互に整合性を保っていることを検証します。
+   */
+  describe('Task 6: データ構造の整合性テスト', () => {
+    /**
+     * 補助Task 6.1: 全データ構造の要素数が一致することをテスト
+     */
+    it('should have consistent element counts across all data structures', () => {
+      const expectedCount = Object.keys(AG_LOGLEVEL).length;
+
+      expect(AG_LOGLEVEL_KEYS).toHaveLength(expectedCount);
+      expect(AG_LOGLEVEL_VALUES).toHaveLength(expectedCount);
+      expect(Object.keys(AG_LOGLEVEL_TO_LABEL_MAP)).toHaveLength(expectedCount);
+      expect(Object.keys(AG_LABEL_TO_LOGLEVEL_MAP)).toHaveLength(expectedCount);
+    });
+
+    /**
+     * 補助Task 6.2: マップのキーと値の型が正しいことをテスト
+     */
+    it('should have correct key-value types in conversion maps', () => {
+      Object.entries(AG_LOGLEVEL_TO_LABEL_MAP).forEach(([levelStr, label]) => {
+        const level = Number(levelStr);
+        expect(typeof level).toBe('number');
+        expect(typeof label).toBe('string');
+        expect(AG_LOGLEVEL_VALUES).toContain(level);
+        expect(AG_LOGLEVEL_KEYS).toContain(label);
+      });
+
+      Object.entries(AG_LABEL_TO_LOGLEVEL_MAP).forEach(([label, level]) => {
+        expect(typeof label).toBe('string');
+        expect(typeof level).toBe('number');
+        expect(AG_LOGLEVEL_KEYS).toContain(label);
+        expect(AG_LOGLEVEL_VALUES).toContain(level);
+      });
+    });
+  });
+});

--- a/packages/@agla-utils/ag-logger/src/_types/__tests__/AgLogLevel.types.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/_types/__tests__/AgLogLevel.types.spec.ts
@@ -59,8 +59,8 @@ describe('AgLogLevel Types and Constants Tests', () => {
      */
     it('should define special log level constants with correct negative values', () => {
       expect(AG_LOGLEVEL.LOG).toBe(-12);
-      expect(AG_LOGLEVEL.FORCE_OUTPUT).toBe(-98);
-      expect(AG_LOGLEVEL.VERBOSE).toBe(-99);
+      expect(AG_LOGLEVEL.VERBOSE).toBe(-11);
+      expect(AG_LOGLEVEL.DEFAULT).toBe(-99);
     });
 
     /**
@@ -92,7 +92,7 @@ describe('AgLogLevel Types and Constants Tests', () => {
     it('should accept all valid log level numeric values', () => {
       const validLogLevels: AgLogLevel[] = [
         AG_LOGLEVEL.VERBOSE,
-        AG_LOGLEVEL.FORCE_OUTPUT,
+        AG_LOGLEVEL.DEFAULT,
         AG_LOGLEVEL.LOG,
         AG_LOGLEVEL.OFF,
         AG_LOGLEVEL.FATAL,
@@ -116,8 +116,8 @@ describe('AgLogLevel Types and Constants Tests', () => {
       expect(AG_LOGLEVEL_VALUES).toHaveLength(10);
       expect(AG_LOGLEVEL_VALUES).toEqual(expect.arrayContaining([
         -99,
-        -98,
         -12,
+        -11,
         0,
         1,
         2,
@@ -145,7 +145,7 @@ describe('AgLogLevel Types and Constants Tests', () => {
     it('should accept all valid log level label strings', () => {
       const validLabels: AgLogLevelLabel[] = [
         'VERBOSE',
-        'FORCE_OUTPUT',
+        'DEFAULT',
         'LOG',
         'OFF',
         'FATAL',
@@ -170,7 +170,7 @@ describe('AgLogLevel Types and Constants Tests', () => {
       expect(AG_LOGLEVEL_KEYS).toHaveLength(10);
       expect(AG_LOGLEVEL_KEYS).toEqual(expect.arrayContaining([
         'VERBOSE',
-        'FORCE_OUTPUT',
+        'DEFAULT',
         'LOG',
         'OFF',
         'FATAL',
@@ -205,7 +205,7 @@ describe('AgLogLevel Types and Constants Tests', () => {
       expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.DEBUG]).toBe('DEBUG');
       expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.TRACE]).toBe('TRACE');
       expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.LOG]).toBe('LOG');
-      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.FORCE_OUTPUT]).toBe('FORCE_OUTPUT');
+      expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.DEFAULT]).toBe('DEFAULT');
       expect(AG_LOGLEVEL_TO_LABEL_MAP[AG_LOGLEVEL.VERBOSE]).toBe('VERBOSE');
     });
 
@@ -221,7 +221,7 @@ describe('AgLogLevel Types and Constants Tests', () => {
       expect(AG_LABEL_TO_LOGLEVEL_MAP['DEBUG']).toBe(AG_LOGLEVEL.DEBUG);
       expect(AG_LABEL_TO_LOGLEVEL_MAP['TRACE']).toBe(AG_LOGLEVEL.TRACE);
       expect(AG_LABEL_TO_LOGLEVEL_MAP['LOG']).toBe(AG_LOGLEVEL.LOG);
-      expect(AG_LABEL_TO_LOGLEVEL_MAP['FORCE_OUTPUT']).toBe(AG_LOGLEVEL.FORCE_OUTPUT);
+      expect(AG_LABEL_TO_LOGLEVEL_MAP['LOG']).toBe(AG_LOGLEVEL.LOG);
       expect(AG_LABEL_TO_LOGLEVEL_MAP['VERBOSE']).toBe(AG_LOGLEVEL.VERBOSE);
     });
 
@@ -254,7 +254,7 @@ describe('AgLogLevel Types and Constants Tests', () => {
       const minLogLevel = Math.min(...AG_LOGLEVEL_VALUES);
       const maxLogLevel = Math.max(...AG_LOGLEVEL_VALUES);
 
-      expect(minLogLevel).toBe(AG_LOGLEVEL.VERBOSE);
+      expect(minLogLevel).toBe(AG_LOGLEVEL.DEFAULT);
       expect(maxLogLevel).toBe(AG_LOGLEVEL.TRACE);
       expect(minLogLevel).toBeLessThan(maxLogLevel);
     });
@@ -270,9 +270,9 @@ describe('AgLogLevel Types and Constants Tests', () => {
       expect(AG_LOGLEVEL.INFO).toBeLessThan(AG_LOGLEVEL.DEBUG);
       expect(AG_LOGLEVEL.DEBUG).toBeLessThan(AG_LOGLEVEL.TRACE);
 
-      expect(AG_LOGLEVEL.VERBOSE).toBeLessThan(AG_LOGLEVEL.FORCE_OUTPUT);
-      expect(AG_LOGLEVEL.FORCE_OUTPUT).toBeLessThan(AG_LOGLEVEL.LOG);
-      expect(AG_LOGLEVEL.LOG).toBeLessThan(AG_LOGLEVEL.OFF);
+      expect(AG_LOGLEVEL.DEFAULT).toBeLessThan(AG_LOGLEVEL.LOG);
+      expect(AG_LOGLEVEL.LOG).toBeLessThan(AG_LOGLEVEL.VERBOSE);
+      expect(AG_LOGLEVEL.VERBOSE).toBeLessThan(AG_LOGLEVEL.OFF);
     });
 
     /**

--- a/packages/@agla-utils/ag-logger/src/internal/AgLoggerConfig.class.ts
+++ b/packages/@agla-utils/ag-logger/src/internal/AgLoggerConfig.class.ts
@@ -87,7 +87,7 @@ export class AgLoggerConfig {
   private clearLoggerMap(): void {
     this._loggerMap.clear();
     this._loggerMap.set(AG_LOGLEVEL.VERBOSE, NullLogger);
-    this._loggerMap.set(AG_LOGLEVEL.FORCE_OUTPUT, NullLogger);
+    this._loggerMap.set(AG_LOGLEVEL.LOG, NullLogger);
     this._loggerMap.set(AG_LOGLEVEL.OFF, NullLogger);
     this._loggerMap.set(AG_LOGLEVEL.FATAL, NullLogger);
     this._loggerMap.set(AG_LOGLEVEL.ERROR, NullLogger);
@@ -235,7 +235,7 @@ export class AgLoggerConfig {
       return false;
     }
 
-    if (level === AG_LOGLEVEL.FORCE_OUTPUT) {
+    if (level === AG_LOGLEVEL.LOG) {
       return true;
     }
 

--- a/packages/@agla-utils/ag-logger/src/internal/AgLoggerConfig.class.ts
+++ b/packages/@agla-utils/ag-logger/src/internal/AgLoggerConfig.class.ts
@@ -247,6 +247,10 @@ export class AgLoggerConfig {
       return false;
     }
 
+    if (level === AG_LOGLEVEL.DEFAULT) {
+      return AG_LOGLEVEL.INFO <= this._options.logLevel;
+    }
+
     // For other levels, only show messages at or below the configured level
     // Lower numbers = less verbose, higher numbers = more verbose
     // So we show messages when their level is <= the configured level

--- a/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/JsonFormatter.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/JsonFormatter.spec.ts
@@ -132,11 +132,11 @@ describe('JsonFormatter', () => {
   });
 
   /**
-   * Tests FORCE_OUTPUT level formatting without level field.
+   * Tests LOG level formatting without level field.
    */
-  it('formats FORCE_OUTPUT level without level field', () => {
+  it('formats LOG level without level field', () => {
     const logMessage: AgLogMessage = {
-      logLevel: AG_LOGLEVEL.FORCE_OUTPUT,
+      logLevel: AG_LOGLEVEL.LOG,
       timestamp: new Date('2025-01-01T12:00:00.000Z'),
       message: 'Force output message',
       args: [],

--- a/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/PlainFormatter.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/PlainFormatter.spec.ts
@@ -92,11 +92,11 @@ describe('PlainFormatter', () => {
   });
 
   /**
-   * Tests FORCE_OUTPUT level formatting without brackets.
+   * Tests LOG level formatting without brackets.
    */
-  it('formats FORCE_OUTPUT level without brackets', () => {
+  it('formats LOG level without brackets', () => {
     const logMessage: AgLogMessage = {
-      logLevel: AG_LOGLEVEL.FORCE_OUTPUT,
+      logLevel: AG_LOGLEVEL.LOG,
       timestamp: new Date('2025-01-01T12:00:00.000Z'),
       message: 'Force output message',
       args: [],

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/ConsoleLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/ConsoleLogger.ts
@@ -30,13 +30,7 @@ export const ConsoleLogger: AgLoggerFunction = (formattedLogMessage: AgFormatted
  * Mapping of log level codes to their respective console logging functions.
  * Uses appropriate console methods per log level for better log categorization.
  */
-export const ConsoleLoggerMap: AgLoggerMap = {
-  [AG_LOGLEVEL.VERBOSE]: (formattedMessage: AgFormattedLogMessage) => {
-    console.debug(formattedMessage);
-  },
-  [AG_LOGLEVEL.FORCE_OUTPUT]: (formattedMessage: AgFormattedLogMessage) => {
-    console.log(formattedMessage);
-  },
+export const ConsoleLoggerMap: Partial<AgLoggerMap> = {
   [AG_LOGLEVEL.OFF]: NullLogger,
   [AG_LOGLEVEL.FATAL]: (formattedMessage: AgFormattedLogMessage) => {
     console.error(formattedMessage);
@@ -55,6 +49,13 @@ export const ConsoleLoggerMap: AgLoggerMap = {
   },
   [AG_LOGLEVEL.TRACE]: (formattedMessage: AgFormattedLogMessage) => {
     console.debug(formattedMessage);
+  },
+  // special level
+  [AG_LOGLEVEL.VERBOSE]: (formattedMessage: AgFormattedLogMessage) => {
+    console.debug(formattedMessage);
+  },
+  [AG_LOGLEVEL.LOG]: (formattedMessage: AgFormattedLogMessage) => {
+    console.log(formattedMessage);
   },
 };
 

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
@@ -128,7 +128,7 @@ export class E2eMockLogger implements AgLoggerInterface {
 
   log(message: AgFormattedLogMessage): void {
     const mockLogger = this.getCurrentMockLogger();
-    mockLogger.executeLog(AG_LOGLEVEL.FORCE_OUTPUT, message);
+    mockLogger.executeLog(AG_LOGLEVEL.LOG, message);
   }
 
   /**

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/E2eMockLogger.ts
@@ -195,7 +195,7 @@ export class E2eMockLogger implements AgLoggerInterface {
    * Create AgLoggerMap for the current test.
    * This provides level-specific logging functions.
    */
-  createLoggerMap(): AgLoggerMap {
+  createLoggerMap(): Partial<AgLoggerMap> {
     return {
       [AG_LOGLEVEL.OFF]: () => {},
       [AG_LOGLEVEL.FATAL]: (message: AgFormattedLogMessage) => this.fatal(message),
@@ -206,7 +206,7 @@ export class E2eMockLogger implements AgLoggerInterface {
       [AG_LOGLEVEL.TRACE]: (message: AgFormattedLogMessage) => this.trace(message),
       // logger for special log level
       [AG_LOGLEVEL.VERBOSE]: (message: AgFormattedLogMessage) => this.verbose(message),
-      [AG_LOGLEVEL.FORCE_OUTPUT]: (message: AgFormattedLogMessage) => this.log(message),
+      [AG_LOGLEVEL.LOG]: (message: AgFormattedLogMessage) => this.log(message),
     };
   }
 }

--- a/packages/@agla-utils/ag-logger/src/plugins/logger/MockLogger.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/logger/MockLogger.ts
@@ -156,7 +156,7 @@ export class AgMockBufferLogger {
    * @param logLevel - The log level to get the logger function for
    * @returns The logger function for the specified level
    */
-  getLoggerFunction(logLevel: AgLogLevel): AgLoggerFunction {
+  getLoggerFunction(logLevel: AgLogLevel = AG_LOGLEVEL.DEFAULT): AgLoggerFunction {
     this.validateLogLevel(logLevel);
     return this.defaultLoggerMap[logLevel] ?? NullLogger;
   }
@@ -166,7 +166,7 @@ export class AgMockBufferLogger {
    * This provides level-specific logging functions.
    */
   createLoggerMap(): AgLoggerMap {
-    return Object.fromEntries(
+    const _loggerMap = Object.fromEntries(
       (Object.values(AG_LOGLEVEL) as AgLogLevel[]).map((level) => [
         level,
         level === AG_LOGLEVEL.OFF
@@ -174,6 +174,8 @@ export class AgMockBufferLogger {
           : ((message: AgFormattedLogMessage): void => this.executeLog(level, message)).bind(this),
       ]),
     ) as AgLoggerMap;
+    _loggerMap[AG_LOGLEVEL.DEFAULT] = this.default.bind(this);
+    return _loggerMap;
   }
 }
 

--- a/packages/@agla-utils/ag-logger/src/utils/AgLogHelpers.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/AgLogHelpers.ts
@@ -20,9 +20,8 @@ export const AgToLabel = (level: AgLogLevel): AgLogLevelLabel | '' => {
     return '' as AgLogLevelLabel;
   }
 
-  // FORCE_OUTPUT時は空文字を返してラベルを表示しない
-  // Special handling for FORCE_OUTPUT - return empty string
-  if (level === AG_LOGLEVEL.FORCE_OUTPUT) {
+  // return empty string if log level is LOG
+  if (level === AG_LOGLEVEL.LOG) {
     return '' as AgLogLevelLabel;
   }
 

--- a/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/conversion.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/conversion.spec.ts
@@ -49,8 +49,8 @@ describe('AgLogHelpers: Conversion Functions', () => {
       });
 
       describe('Special log levels', () => {
-        it('should return empty string for FORCE_OUTPUT level', () => {
-          expect(AgToLabel(AG_LOGLEVEL.FORCE_OUTPUT)).toBe('');
+        it('should return empty string for LOG level', () => {
+          expect(AgToLabel(AG_LOGLEVEL.LOG)).toBe('');
         });
       });
 
@@ -58,16 +58,16 @@ describe('AgLogHelpers: Conversion Functions', () => {
         it('should get correct values from AG_LOGLEVEL_TO_LABEL_MAP', () => {
           Object.values(AG_LOGLEVEL).forEach((level) => {
             const result = AgToLabel(level);
-            const expected = level === AG_LOGLEVEL.FORCE_OUTPUT
+            const expected = (level === AG_LOGLEVEL.LOG)
               ? ''
               : AG_LOGLEVEL_TO_LABEL_MAP[level];
             expect(result).toBe(expected);
           });
         });
 
-        it('should handle all AG_LOGLEVEL (except FORCE_OUTPUT) values consistently', () => {
+        it('should handle all AG_LOGLEVEL (except LOG) values consistently', () => {
           Object.entries(AG_LOGLEVEL)
-            .filter(([_key, value]) => (value !== AG_LOGLEVEL.FORCE_OUTPUT))
+            .filter(([_key, value]) => (value !== AG_LOGLEVEL.LOG))
             .forEach(([key, value]) => {
               const stringLabel = AgToLabel(value);
               expect(stringLabel).toBe(key);
@@ -76,7 +76,7 @@ describe('AgLogHelpers: Conversion Functions', () => {
 
         it('should return consistent uppercase format', () => {
           Object.values(AG_LOGLEVEL)
-            .filter((level) => (level !== AG_LOGLEVEL.FORCE_OUTPUT))
+            .filter((level) => (level !== AG_LOGLEVEL.LOG))
             .forEach((level) => {
               const label = AgToLabel(level);
               expect(label).toBe(label.toUpperCase());
@@ -185,6 +185,7 @@ describe('AgLogHelpers: Conversion Functions', () => {
           expect(AgToLogLevel('DEBUG' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.DEBUG);
           expect(AgToLogLevel('TRACE' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.TRACE);
           expect(AgToLogLevel('VERBOSE' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.VERBOSE);
+          expect(AgToLogLevel('LOG' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.LOG);
         });
       });
 
@@ -198,6 +199,7 @@ describe('AgLogHelpers: Conversion Functions', () => {
           expect(AgToLogLevel('debug' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.DEBUG);
           expect(AgToLogLevel('trace' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.TRACE);
           expect(AgToLogLevel('verbose' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.VERBOSE);
+          expect(AgToLogLevel('log' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.LOG);
         });
 
         it('should handle mixed case string labels', () => {
@@ -209,6 +211,7 @@ describe('AgLogHelpers: Conversion Functions', () => {
           expect(AgToLogLevel('Debug' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.DEBUG);
           expect(AgToLogLevel('Trace' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.TRACE);
           expect(AgToLogLevel('Verbose' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.VERBOSE);
+          expect(AgToLogLevel('Log' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.LOG);
         });
       });
     });
@@ -217,7 +220,6 @@ describe('AgLogHelpers: Conversion Functions', () => {
       describe('Invalid string labels', () => {
         it('should return undefined for invalid string labels', () => {
           expect(AgToLogLevel('INVALID' as AgLogLevelLabel)).toBeUndefined();
-          expect(AgToLogLevel('LOG' as AgLogLevelLabel)).toBeUndefined();
           expect(AgToLogLevel('LEVEL' as AgLogLevelLabel)).toBeUndefined();
           expect(AgToLogLevel('UNKNOWN' as AgLogLevelLabel)).toBeUndefined();
         });

--- a/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/conversion.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/conversion.spec.ts
@@ -186,6 +186,7 @@ describe('AgLogHelpers: Conversion Functions', () => {
           expect(AgToLogLevel('TRACE' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.TRACE);
           expect(AgToLogLevel('VERBOSE' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.VERBOSE);
           expect(AgToLogLevel('LOG' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.LOG);
+          expect(AgToLogLevel('DEFAULT' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.DEFAULT);
         });
       });
 
@@ -200,6 +201,7 @@ describe('AgLogHelpers: Conversion Functions', () => {
           expect(AgToLogLevel('trace' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.TRACE);
           expect(AgToLogLevel('verbose' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.VERBOSE);
           expect(AgToLogLevel('log' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.LOG);
+          expect(AgToLogLevel('default' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.DEFAULT);
         });
 
         it('should handle mixed case string labels', () => {
@@ -212,6 +214,7 @@ describe('AgLogHelpers: Conversion Functions', () => {
           expect(AgToLogLevel('Trace' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.TRACE);
           expect(AgToLogLevel('Verbose' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.VERBOSE);
           expect(AgToLogLevel('Log' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.LOG);
+          expect(AgToLogLevel('Default' as AgLogLevelLabel)).toBe(AG_LOGLEVEL.DEFAULT);
         });
       });
     });

--- a/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/validation.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/validation.spec.ts
@@ -15,8 +15,8 @@ describe('AgLogHelpers: Validation Functions', () => {
   describe('isValidLogLevel: LogLevel validation', () => {
     describe('正常系: Valid LogLevel inputs', () => {
       describe('Standard log levels', () => {
-        it('should return true for FORCE_OUTPUT level', () => {
-          expect(isValidLogLevel(AG_LOGLEVEL.FORCE_OUTPUT)).toBe(true);
+        it('should return true for LOG level', () => {
+          expect(isValidLogLevel(AG_LOGLEVEL.LOG)).toBe(true);
         });
 
         it('should return true for OFF level', () => {
@@ -55,7 +55,7 @@ describe('AgLogHelpers: Validation Functions', () => {
       describe('Numeric literal validation', () => {
         it('should return true for numeric literals matching AG_LOGLEVEL values', () => {
           expect(isValidLogLevel(-99 as AgLogLevel)).toBe(true); // VERBOSE
-          expect(isValidLogLevel(-98 as AgLogLevel)).toBe(true); // FORCE_OUTPUT
+          expect(isValidLogLevel(-12 as AgLogLevel)).toBe(true); // LOG
           expect(isValidLogLevel(0 as AgLogLevel)).toBe(true); // OFF
           expect(isValidLogLevel(1 as AgLogLevel)).toBe(true); // FATAL
           expect(isValidLogLevel(2 as AgLogLevel)).toBe(true); // ERROR
@@ -98,7 +98,7 @@ describe('AgLogHelpers: Validation Functions', () => {
           expect(isValidLogLevel('1' as unknown as AgLogLevel)).toBe(false);
           expect(isValidLogLevel('4' as unknown as AgLogLevel)).toBe(false);
           expect(isValidLogLevel('-99' as unknown as AgLogLevel)).toBe(false);
-          expect(isValidLogLevel('-98' as unknown as AgLogLevel)).toBe(false);
+          expect(isValidLogLevel('-12' as unknown as AgLogLevel)).toBe(false);
         });
 
         it('should return false for log level label strings', () => {
@@ -234,7 +234,7 @@ describe('AgLogHelpers: Validation Functions', () => {
         it('should return false for boundary edge values', () => {
           expect(isValidLogLevel(-101 as AgLogLevel)).toBe(false); // Just below VERBOSE
           expect(isValidLogLevel(7 as AgLogLevel)).toBe(false); // Just above TRACE
-          expect(isValidLogLevel(-97 as AgLogLevel)).toBe(false); // Between FORCE_OUTPUT and VERBOSE
+          expect(isValidLogLevel(-97 as AgLogLevel)).toBe(false); // Between LOG and VERBOSE
         });
       });
 
@@ -316,8 +316,8 @@ describe('AgLogHelpers: Validation Functions', () => {
       });
 
       it('should handle gaps in the enum correctly', () => {
-        // There's a gap between FORCE_OUTPUT(-98) and VERBOSE(-99)
-        expect(isValidLogLevel(-98 as AgLogLevel)).toBe(true); // FORCE_OUTPUT
+        // There's a gap between LOG(-12) and VERBOSE(-99)
+        expect(isValidLogLevel(-12 as AgLogLevel)).toBe(true); // LOG
         expect(isValidLogLevel(-99 as AgLogLevel)).toBe(true); // VERBOSE
 
         // Values in the gap should be invalid

--- a/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/validation.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/__tests__/agLogHelpers/validation.spec.ts
@@ -50,12 +50,17 @@ describe('AgLogHelpers: Validation Functions', () => {
         it('should return true for VERBOSE level', () => {
           expect(isValidLogLevel(AG_LOGLEVEL.VERBOSE)).toBe(true);
         });
+
+        it('should return true for DEFAULT level', () => {
+          expect(isValidLogLevel(AG_LOGLEVEL.DEFAULT)).toBe(true);
+        });
       });
 
       describe('Numeric literal validation', () => {
         it('should return true for numeric literals matching AG_LOGLEVEL values', () => {
-          expect(isValidLogLevel(-99 as AgLogLevel)).toBe(true); // VERBOSE
+          expect(isValidLogLevel(-99 as AgLogLevel)).toBe(true); // DEFAULT
           expect(isValidLogLevel(-12 as AgLogLevel)).toBe(true); // LOG
+          expect(isValidLogLevel(-11 as AgLogLevel)).toBe(true); // VERBOSE
           expect(isValidLogLevel(0 as AgLogLevel)).toBe(true); // OFF
           expect(isValidLogLevel(1 as AgLogLevel)).toBe(true); // FATAL
           expect(isValidLogLevel(2 as AgLogLevel)).toBe(true); // ERROR

--- a/packages/@agla-utils/ag-logger/tests/integration/AgLoggerManager.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/AgLoggerManager.integration.spec.ts
@@ -50,7 +50,7 @@ describe('AgLoggerManager Integration Tests', () => {
     [AG_LOGLEVEL.TRACE]: NullLogger,
     //
     [AG_LOGLEVEL.VERBOSE]: NullLogger,
-    [AG_LOGLEVEL.FORCE_OUTPUT]: NullLogger,
+    [AG_LOGLEVEL.LOG]: NullLogger,
   };
   /**
    * Tests singleton behavior and instance management

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/basic.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/basic.integration.spec.ts
@@ -100,7 +100,7 @@ describe('AgLogger Basic Integration Tests', () => {
 
         // ロガーマネージャー設定の共有
         logger1.setLoggerConfig({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: JsonFormatter,
         });
 
@@ -108,7 +108,7 @@ describe('AgLogger Basic Integration Tests', () => {
         logger2.info('test message');
 
         expect(mockLogger.getTotalMessageCount()).toBe(1);
-        const message = mockLogger.getLastMessage(AG_LOGLEVEL.INFO) as string;
+        const message = mockLogger.getLastMessage(AG_LOGLEVEL.DEFAULT) as string;
         expect(() => JSON.parse(message)).not.toThrow();
         const parsed = JSON.parse(message);
         expect(parsed.message).toBe('test message');

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/configuration.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/configuration.integration.spec.ts
@@ -73,7 +73,7 @@ describe('AgLogger Configuration Integration Tests', () => {
         const defaultLogger = new MockLogger.buffer();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: defaultLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: defaultLogger.getLoggerFunction(),
           formatter: MockFormatter.passthrough,
           loggerMap: {
             [AG_LOGLEVEL.ERROR]: errorLogger.getLoggerFunction(AG_LOGLEVEL.ERROR),
@@ -113,18 +113,18 @@ describe('AgLogger Configuration Integration Tests', () => {
         const tempLogger1 = new MockLogger.buffer();
         const tempLogger2 = new MockLogger.buffer();
 
-        logger.setLoggerConfig({ defaultLogger: tempLogger1.getLoggerFunction(AG_LOGLEVEL.INFO) });
+        logger.setLoggerConfig({ defaultLogger: tempLogger1.getLoggerFunction() });
         logger.setLoggerConfig({
           loggerMap: { [AG_LOGLEVEL.ERROR]: tempLogger2.getLoggerFunction(AG_LOGLEVEL.ERROR) },
         });
         logger.setLoggerConfig({ formatter: MockFormatter.json });
-        logger.setLoggerConfig({ defaultLogger: finalLogger.getLoggerFunction(AG_LOGLEVEL.INFO) });
+        logger.setLoggerConfig({ defaultLogger: finalLogger.getLoggerFunction() });
 
         logger.logLevel = AG_LOGLEVEL.INFO;
         logger.info('test message');
 
         expect(finalLogger.getTotalMessageCount()).toBe(1);
-        const message = finalLogger.getLastMessage(AG_LOGLEVEL.INFO) as string;
+        const message = finalLogger.getLastMessage(AG_LOGLEVEL.DEFAULT) as string;
         expect(() => JSON.parse(message)).not.toThrow();
         const parsed = JSON.parse(message);
         expect(parsed.message).toBe('test message');

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/dataProcessing.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/dataProcessing.integration.spec.ts
@@ -90,7 +90,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         setupTestContext();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: vi.fn().mockImplementation((logMessage) => {
             // フォーマッターで循環参照を処理するシナリオ
             try {
@@ -127,7 +127,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: errorHandlingFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;
@@ -140,7 +140,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         expect(capturedError).toBeTruthy();
         expect(capturedError).toContain('circular');
         expect(mockLogger.getTotalMessageCount()).toBe(1);
-        const messages = mockLogger.getMessages(AG_LOGLEVEL.INFO);
+        const messages = mockLogger.getMessages(AG_LOGLEVEL.DEFAULT);
         expect(messages[0]).toContain('Circular Reference:');
         expect(messages[0]).toContain('Testing circular reference handling');
       });
@@ -169,7 +169,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: resilientFormatter,
           loggerMap: mockLogger.defaultLoggerMap,
         });
@@ -235,7 +235,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: safeFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;
@@ -262,7 +262,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         expect(() => logger.info('Deep circular reference test', deepCircular)).not.toThrow();
         expect(mockLogger.getTotalMessageCount()).toBe(1);
 
-        const logOutput = mockLogger.getMessages(AG_LOGLEVEL.INFO)[0];
+        const logOutput = mockLogger.getMessages(AG_LOGLEVEL.DEFAULT)[0];
         expect(logOutput).toContain('Deep circular reference test');
         expect(logOutput).toContain('[Circular]');
       });
@@ -291,7 +291,7 @@ describe('AgLogger Data Processing Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: circularSafeFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/edgecases.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/edgecases.integration.spec.ts
@@ -65,7 +65,7 @@ describe('AgLogger Complex Edge Cases Integration Tests', () => {
     it('should handle deeply nested objects', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -90,7 +90,7 @@ describe('AgLogger Complex Edge Cases Integration Tests', () => {
     it('should handle errors with custom properties', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -113,7 +113,7 @@ describe('AgLogger Complex Edge Cases Integration Tests', () => {
     it('should handle multiple error types simultaneously', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -137,7 +137,7 @@ describe('AgLogger Complex Edge Cases Integration Tests', () => {
     it('should handle various whitespace types consistently', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/filtering.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/filtering.integration.spec.ts
@@ -99,7 +99,7 @@ describe('AgLogger Filtering Integration Tests', () => {
         setupTestContext();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: mockFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.OFF;
@@ -193,7 +193,7 @@ describe('AgLogger Filtering Integration Tests', () => {
         setupTestContext();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: MockFormatter.messageOnly,
           loggerMap: mockLogger.defaultLoggerMap,
         });
@@ -243,7 +243,7 @@ describe('AgLogger Filtering Integration Tests', () => {
         });
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: throwingFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;
@@ -263,7 +263,7 @@ describe('AgLogger Filtering Integration Tests', () => {
         setupTestContext();
 
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: PlainFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;

--- a/packages/@agla-utils/ag-logger/tests/integration/aglogger/performance.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/aglogger/performance.integration.spec.ts
@@ -58,22 +58,22 @@ describe('AgLogger Performance Integration Tests', () => {
 
       const mockFormatter = vi.fn().mockImplementation((msg) => msg.message ?? msg);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
 
       // First test synchronous logging to verify setup
       logger.info('sync test');
-      expect(mockLogger.getMessageCount(AG_LOGLEVEL.INFO)).toBe(1);
-      mockLogger.clearMessages(AG_LOGLEVEL.INFO);
+      expect(mockLogger.getMessageCount(AG_LOGLEVEL.DEFAULT)).toBe(1);
+      mockLogger.clearMessages(AG_LOGLEVEL.DEFAULT);
 
       // 同期での高速連続実行テスト（async問題を回避）
       for (let i = 0; i < 10; i++) {
         logger.info(`message ${i}`);
       }
 
-      expect(mockLogger.getMessageCount(AG_LOGLEVEL.INFO)).toBe(10); // 10 loop messages
+      expect(mockLogger.getMessageCount(AG_LOGLEVEL.DEFAULT)).toBe(10); // 10 loop messages
       expect(mockFormatter).toHaveBeenCalledTimes(11); // 1 sync + 10 loop
     });
 
@@ -114,7 +114,7 @@ describe('AgLogger Performance Integration Tests', () => {
       const { mockLogger } = createMock(ctx);
       const mockFormatter = vi.fn().mockImplementation((msg) => msg.message ?? msg);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
 
@@ -125,7 +125,7 @@ describe('AgLogger Performance Integration Tests', () => {
         logger.info('test');
       }
 
-      expect(mockLogger.getMessages(AG_LOGLEVEL.INFO)).toHaveLength(50); // INFO レベルの時のみ
+      expect(mockLogger.getMessages(AG_LOGLEVEL.DEFAULT)).toHaveLength(50); // INFO レベルの時のみ
 
       ctx.onTestFinished(() => {
         AgLogger.resetSingleton();
@@ -138,7 +138,7 @@ describe('AgLogger Performance Integration Tests', () => {
       const { mockLogger } = createMock(ctx);
       const mockFormatter = vi.fn().mockImplementation((msg) => msg.message ?? msg);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
         loggerMap: mockLogger.defaultLoggerMap,
       });
@@ -164,7 +164,7 @@ describe('AgLogger Performance Integration Tests', () => {
       const { mockLogger } = createMock(ctx);
       // Setup
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
         loggerMap: mockLogger.defaultLoggerMap,
       });
@@ -195,7 +195,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should handle very long messages', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -203,14 +203,14 @@ describe('AgLogger Performance Integration Tests', () => {
       const longMessage = 'x'.repeat(10000);
       logger.info(longMessage);
 
-      expect(mockLogger.getMessageCount(AG_LOGLEVEL.INFO)).toBe(1);
+      expect(mockLogger.getMessageCount(AG_LOGLEVEL.DEFAULT)).toBe(1);
     });
 
     // 目的: 引数の大量投入時の堅牢性
     it('should handle large number of arguments', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -225,7 +225,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should handle large objects in arguments', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -249,7 +249,7 @@ describe('AgLogger Performance Integration Tests', () => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       for (let i = 0; i < 50; i++) {
         const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+          defaultLogger: mockLogger.getLoggerFunction(),
           formatter: mockFormatter,
         });
         logger.logLevel = AG_LOGLEVEL.INFO;
@@ -264,7 +264,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should maintain state consistency under stress', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
 
@@ -289,7 +289,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should maintain consistency with rapid state changes and complex data', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
         loggerMap: mockLogger.createLoggerMap(),
       });
@@ -328,7 +328,7 @@ describe('AgLogger Performance Integration Tests', () => {
       });
 
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: stressFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;
@@ -351,7 +351,7 @@ describe('AgLogger Performance Integration Tests', () => {
     it('should handle Unicode characters in high-volume processing', (ctx) => {
       const { mockLogger, mockFormatter } = createMock(ctx);
       const logger = AgLogger.createLogger({
-        defaultLogger: mockLogger.getLoggerFunction(AG_LOGLEVEL.INFO),
+        defaultLogger: mockLogger.getLoggerFunction(),
         formatter: mockFormatter,
       });
       logger.logLevel = AG_LOGLEVEL.INFO;


### PR DESCRIPTION
**Title:**  
`feat(logger): add DEFAULT log level & rename FORCE_OUTPUT to LOG`

---

## ✨ Overview
`defaultLogger` に `DEFAULT` ログレベルを追加し、ログレベル管理の一貫性を改善しました。  
また、既存の `FORCE_OUTPUT` ログレベルを `LOG` に改名し、意味と用途をより明確化。  
併せて、VERBOSE モードなどの値変更、型・項目リスト・変換マップの自動導出化を行い、関連テストを更新しました。

---

## 🔧 Changes
- **Log Levels**
  - `DEFAULT` ログレベルを追加（内部的には `INFO` と同等）
  - `FORCE_OUTPUT` → `LOG` に名称変更
  - `VERBOSE` モードなど一部値を整理・変更
- **型/構造**
  - `AgLogLevel` 型・項目リスト・ラベル変換マップを自動導出化
- **Logger 実装**
  - `MockLogger` に `DEFAULT` ログレベルを追加
  - `AgLoggerConfig.shouldOutput` に `DEFAULT` 判定を追加（`INFO` 同等）
- **Tests**
  - `DEFAULT` / `LOG` ログレベルに対応したテストケースを追加・修正
  - 既存テストを新しいレベル値・名称に対応
- **Integration**
  - integration.spec 内で `DEFAULT` ログレベルを使用するよう変更

---

## ✅ Checklist
- [ ] Lint OK
- [ ] Test OK
- [ ] Conventional Commits 準拠
- [ ] ドキュメント更新（該当なし）
