### PR TITLE
test(integration): restructure and improve mock usage and cleanup

### DIFF
--- a/packages/@agla-utils/ag-logger/docs/guide/user-guide.guide.md
+++ b/packages/@agla-utils/ag-logger/docs/guide/user-guide.guide.md
@@ -1,0 +1,521 @@
+---
+header:
+- src: user-guide.guide.md
+- @(#): AgLogger ユーザーガイド
+title: AgLogger ユーザーガイド
+description: AgLoggerを簡単に使用できるようになるための包括的なユーザーガイド
+version: 1.0.0
+created: 2025-08-19
+authors:
+  - atsushifx
+changes:
+  - 2025-08-19: 初版作成
+copyright:
+  - Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+  - This software is released under the MIT License.
+  - https://opensource.org/licenses/MIT
+---
+
+# AgLogger ユーザーガイド
+
+AgLoggerは、TypeScript/JavaScript向けの強力で柔軟な構造化ログライブラリです。シングルトンパターンベースの設計により、アプリケーション全体で一貫したログ管理を提供します。
+
+## クイックスタート
+
+### 基本的な使用方法
+
+```typescript
+import { AG_LOGLEVEL, AgLogger, ConsoleLogger, PlainFormatter } from '@agla-utils/ag-logger';
+
+// ロガーの初期化
+const logger = AgLogger.createLogger({
+  defaultLogger: ConsoleLogger,
+  formatter: PlainFormatter,
+  logLevel: AG_LOGLEVEL.INFO,
+});
+
+// ログの出力
+logger.info('アプリケーションを開始します');
+logger.warn('設定ファイルが見つかりません', { path: '/config/app.json' });
+logger.error('データベース接続に失敗', { error: 'Connection timeout' });
+```
+
+### マネージャー経由での使用
+
+```typescript
+import { AgLoggerManager, getLogger } from '@agla-utils/ag-logger';
+
+// マネージャーの作成と設定
+AgLoggerManager.createManager({
+  defaultLogger: ConsoleLogger,
+  formatter: PlainFormatter,
+});
+
+// どこからでもロガーを取得
+const logger = getLogger();
+logger.info('マネージャー経由でのログ出力');
+```
+
+## コア概念
+
+### ログレベル
+
+AgLoggerは以下のログレベルをサポートしています：
+
+| レベル | 値 | 用途                                   |
+| ------ | -- | -------------------------------------- |
+| OFF    | 0  | ログ出力なし                           |
+| FATAL  | 1  | アプリケーション終了を伴う致命的エラー |
+| ERROR  | 2  | アプリケーションを停止しないエラー     |
+| WARN   | 3  | 潜在的に有害な状況の警告               |
+| INFO   | 4  | 一般的な情報メッセージ                 |
+| DEBUG  | 5  | デバッグ用の詳細情報                   |
+| TRACE  | 6  | 非常に詳細なトレース情報               |
+
+#### 特別なログレベル
+
+- **VERBOSE** (-11): 詳細モード専用
+- **LOG** (-12): 強制出力 (フィルタリングされない)
+
+### フォーマッター
+
+#### PlainFormatter
+
+テキスト形式でログを出力します：
+
+```typescript
+import { PlainFormatter } from '@agla-utils/ag-logger';
+
+// 出力例: 2025-08-19T10:30:45Z [INFO] Starting application
+```
+
+#### JsonFormatter
+
+JSON形式でログを出力します：
+
+```typescript
+import { JsonFormatter } from '@agla-utils/ag-logger';
+
+// 出力例: {"timestamp":"2025-08-19T10:30:45.123Z","level":"INFO","message":"Starting application"}
+```
+
+### ロガー
+
+#### ConsoleLogger
+
+標準のconsoleオブジェクトに出力します：
+
+```typescript
+import { ConsoleLogger } from '@agla-utils/ag-logger';
+
+const logger = AgLogger.createLogger({
+  defaultLogger: ConsoleLogger,
+});
+```
+
+#### MockLogger
+
+テスト用のモックロガーです：
+
+```typescript
+import { MockLogger } from '@agla-utils/ag-logger';
+
+const mockLogger = MockLogger.buffer;
+const logger = AgLogger.createLogger({
+  defaultLogger: mockLogger;
+});
+
+// ログ呼び出しの検証
+expect(mockLogger.getMessageCount(AG_LOGLEVEL.INFO)).toBe(1)
+```
+
+## API リファレンス
+
+### AgLogger クラス
+
+#### メソッド
+
+##### createLogger(options?: AgLoggerOptions): AgLogger
+
+シングルトンインスタンスを作成または取得します。
+
+```typescript
+const logger = AgLogger.createLogger({
+  defaultLogger: ConsoleLogger,
+  formatter: PlainFormatter,
+  logLevel: AG_LOGLEVEL.DEBUG,
+  loggerMap: {
+    [AG_LOGLEVEL.ERROR]: CustomErrorLogger,
+  },
+});
+```
+
+##### ログメソッド
+
+各ログレベルに対応するメソッドを提供します：
+
+```typescript
+logger.fatal('致命的エラー');
+logger.error('エラーメッセージ');
+logger.warn('警告メッセージ');
+logger.info('情報メッセージ');
+logger.debug('デバッグ情報');
+logger.trace('トレース情報');
+logger.log('強制出力'); // フィルタリングされない
+logger.verbose('詳細情報'); // verboseモード時のみ出力
+```
+
+##### setLoggerConfig(options: AgLoggerOptions): void
+
+ロガーの設定を更新します：
+
+```typescript
+logger.setLoggerConfig({
+  formatter: JsonFormatter,
+  logLevel: AG_LOGLEVEL.WARN,
+});
+```
+
+##### setLoggerFunction(logLevel: AgLogLevel, loggerFunction: AgLoggerFunction): boolean
+
+特定のログレベルにカスタムロガー関数を設定します：
+
+```typescript
+logger.setLoggerFunction(AG_LOGLEVEL.ERROR, (message) => {
+  // カスタムエラーログ処理
+  sendToErrorService(message);
+});
+```
+
+### AgLoggerManager クラス
+
+#### メソッド
+
+##### createManager(options?: AgLoggerOptions): AgLoggerManager
+
+マネージャーのシングルトンインスタンスを作成します：
+
+```typescript
+const manager = AgLoggerManager.createManager({
+  defaultLogger: ConsoleLogger,
+  formatter: PlainFormatter,
+});
+```
+
+##### getManager(): AgLoggerManager
+
+既存のマネージャーインスタンスを取得します：
+
+```typescript
+const manager = AgLoggerManager.getManager();
+```
+
+##### getLogger(): AgLogger
+
+管理されているAgLoggerインスタンスを取得します：
+
+```typescript
+const logger = manager.getLogger();
+```
+
+##### setLoggerConfig(options: AgLoggerOptions): void
+
+ロガーの設定を更新します：
+
+```typescript
+manager.setLoggerConfig({
+  logLevel: AG_LOGLEVEL.DEBUG,
+  formatter: JsonFormatter,
+});
+```
+
+## 設定オプション
+
+### AgLoggerOptions
+
+```typescript
+interface AgLoggerOptions {
+  defaultLogger?: AgLoggerFunction;
+  formatter?: AgFormatFunction;
+  logLevel?: AgLogLevel;
+  loggerMap?: Partial<AgLoggerMap<AgLoggerFunction>>;
+}
+```
+
+#### 例：完全な設定
+
+```typescript
+const logger = AgLogger.createLogger({
+  defaultLogger: ConsoleLogger,
+  formatter: PlainFormatter,
+  logLevel: AG_LOGLEVEL.INFO,
+  loggerMap: {
+    [AG_LOGLEVEL.ERROR]: CustomErrorLogger,
+    [AG_LOGLEVEL.WARN]: CustomWarnLogger,
+  },
+});
+```
+
+## 高度な使用法
+
+### カスタムフォーマッター
+
+```typescript
+import type { AgFormatFunction, AgLogMessage } from '@agla-utils/ag-logger';
+
+const customFormatter: AgFormatFunction = (logMessage: AgLogMessage): string => {
+  const { timestamp, logLevel, message, args } = logMessage;
+  return `[${new Date(timestamp).toLocaleTimeString()}] ${message} ${JSON.stringify(args)}`;
+};
+
+logger.setFormatter(customFormatter);
+```
+
+### カスタムロガー
+
+```typescript
+import type { AgLoggerFunction } from '@agla-utils/ag-logger';
+
+const fileLogger: AgLoggerFunction = (message: string) => {
+  // ファイルへの書き込み処理
+  fs.appendFileSync('/var/log/app.log', message + '\n');
+};
+
+logger.setLoggerFunction(AG_LOGLEVEL.ERROR, fileLogger);
+```
+
+### エラーハンドリング
+
+AgLoggerは包括的なエラーハンドリングを提供します：
+
+```typescript
+import { AgLoggerError } from '@agla-utils/ag-logger';
+
+try {
+  const logger = AgLogger.getLogger(); // 初期化前に呼び出すとエラー
+} catch (error) {
+  if (error instanceof AgLoggerError) {
+    console.error('ロガーエラー:', error.message);
+    console.error('エラータイプ:', error.type);
+  }
+}
+```
+
+## 実践的な例
+
+### Webアプリケーションでの使用
+
+```typescript
+import { AG_LOGLEVEL, AgLogger, ConsoleLogger, JsonFormatter } from '@agla-utils/ag-logger';
+
+// アプリケーション初期化時
+const logger = AgLogger.createLogger({
+  defaultLogger: ConsoleLogger,
+  formatter: process.env.NODE_ENV === 'production' ? JsonFormatter : PlainFormatter,
+  logLevel: process.env.NODE_ENV === 'production' ? AG_LOGLEVEL.WARN : AG_LOGLEVEL.DEBUG,
+});
+
+// APIリクエストハンドラー
+app.get('/api/users', async (req, res) => {
+  logger.info('ユーザー一覧取得開始', { userId: req.user?.id });
+
+  try {
+    const users = await userService.getAll();
+    logger.debug('ユーザー取得成功', { count: users.length });
+    res.json(users);
+  } catch (error) {
+    logger.error('ユーザー取得失敗', { error: error.message, stack: error.stack });
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+});
+```
+
+### テストでの使用
+
+```typescript
+import { AgLogger, createMockFormatter, MockLogger } from '@agla-utils/ag-logger';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('UserService', () => {
+  let mockLogger: MockLogger;
+  let logger: AgLogger;
+
+  beforeEach(() => {
+    mockLogger = new MockLogger();
+    logger = AgLogger.createLogger({
+      defaultLogger: mockLogger.logger,
+      formatter: createMockFormatter(),
+    });
+  });
+
+  it('ユーザー作成時にログが出力される', async () => {
+    await userService.create({ name: 'John' });
+
+    expect(mockLogger.hasBeenCalled('info')).toBe(true);
+    expect(mockLogger.getCallCount('info')).toBe(1);
+  });
+});
+```
+
+### マイクロサービスでの使用
+
+```typescript
+import { AgLoggerManager, ConsoleLogger, getLogger, JsonFormatter } from '@agla-utils/ag-logger';
+
+// サービス起動時の初期化
+AgLoggerManager.createManager({
+  defaultLogger: ConsoleLogger,
+  formatter: JsonFormatter,
+});
+
+// 各モジュールで使用
+export class UserService {
+  private logger = getLogger();
+
+  async createUser(userData: CreateUserRequest) {
+    this.logger.info('ユーザー作成開始', { email: userData.email });
+
+    try {
+      const user = await this.userRepository.create(userData);
+      this.logger.info('ユーザー作成成功', { userId: user.id, email: user.email });
+      return user;
+    } catch (error) {
+      this.logger.error('ユーザー作成失敗', {
+        email: userData.email,
+        error: error.message,
+      });
+      throw error;
+    }
+  }
+}
+```
+
+## ベストプラクティス
+
+### 1. 適切なログレベルの選択
+
+```typescript
+// ✅ 良い例
+logger.debug('キャッシュヒット', { key: 'user:123' }); // デバッグ情報
+logger.info('ユーザーログイン', { userId: user.id }); // 重要なビジネスイベント
+logger.warn('レート制限に近づいています', { current: 95, limit: 100 }); // 注意が必要な状況
+logger.error('外部API呼び出し失敗', { api: 'payment', error: error.message }); // エラー状況
+
+// ❌ 悪い例
+logger.error('ユーザーがボタンをクリック'); // エラーレベルの誤用
+logger.debug('致命的なデータベースエラー'); // 重要度の過小評価
+```
+
+### 2. 構造化されたログデータ
+
+```typescript
+// ✅ 良い例
+logger.info('注文処理完了', {
+  orderId: order.id,
+  userId: order.userId,
+  amount: order.total,
+  duration: Date.now() - startTime,
+});
+
+// ❌ 悪い例
+logger.info(`注文${order.id}がユーザー${order.userId}によって${order.total}円で処理されました`);
+```
+
+### 3. パフォーマンスの考慮
+
+```typescript
+// ✅ 良い例：条件付きログ
+if (logger.logLevel >= AG_LOGLEVEL.DEBUG) {
+  const expensiveData = computeExpensiveDebugInfo();
+  logger.debug('詳細デバッグ情報', expensiveData);
+}
+
+// ✅ 良い例：遅延評価
+logger.debug('詳細情報', () => computeExpensiveDebugInfo());
+```
+
+### 4. センシティブ情報の保護
+
+```typescript
+// ✅ 良い例
+logger.info('ユーザー認証成功', {
+  userId: user.id,
+  email: maskEmail(user.email),
+});
+
+// ❌ 悪い例
+logger.info('ユーザー認証成功', {
+  userId: user.id,
+  email: user.email,
+  password: user.password, // センシティブ情報を含む
+});
+
+function maskEmail(email: string): string {
+  const [username, domain] = email.split('@');
+  return `${username.slice(0, 2)}***@${domain}`;
+}
+```
+
+### 5. エラーログの充実
+
+```typescript
+// ✅ 良い例
+try {
+  await processPayment(order);
+} catch (error) {
+  logger.error('決済処理エラー', {
+    orderId: order.id,
+    paymentMethod: order.paymentMethod,
+    error: error.message,
+    stack: error.stack,
+    timestamp: new Date().toISOString(),
+  });
+  throw error;
+}
+```
+
+## トラブルシューティング
+
+### よくある問題
+
+#### 1. "Logger not created" エラー
+
+```typescript
+// 問題: ロガーが初期化されていない
+const logger = AgLogger.getLogger(); // AgLoggerError をスロー
+
+// 解決策: 事前にロガーを作成
+const logger = AgLogger.createLogger();
+// または
+AgLoggerManager.createManager();
+const logger = getLogger();
+```
+
+#### 2. ログが出力されない
+
+```typescript
+// 問題: ログレベルが高すぎる
+logger.logLevel = AG_LOGLEVEL.ERROR;
+logger.info('この情報は出力されません'); // ERROR > INFO のため出力されない
+
+// 解決策: 適切なログレベルを設定
+logger.logLevel = AG_LOGLEVEL.INFO;
+logger.info('この情報は出力されます');
+```
+
+#### 3. フォーマッターが反映されない
+
+```typescript
+// 問題: 設定後にフォーマッターが変更されない
+const logger = AgLogger.createLogger();
+logger.setFormatter(JsonFormatter); // 正しい設定方法
+
+// または設定オブジェクトで指定
+logger.setLoggerConfig({ formatter: JsonFormatter });
+```
+
+## まとめ
+
+AgLoggerは、TypeScript/JavaScript アプリケーションで強力で柔軟なログ機能を提供します。シングルトンパターンによる一貫したログ管理、豊富なカスタマイゼーションオプション、包括的なテスト支援により、開発からプロダクションまでのあらゆる段階でアプリケーションの可観測性を向上させます。
+
+このガイドを参考に、あなたのプロジェクトに最適なログ戦略を構築してください。

--- a/packages/@agla-utils/ag-logger/shared/types/AgLogger.interface.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgLogger.interface.ts
@@ -7,9 +7,9 @@
 // https://opensource.org/licenses/MIT
 
 // type
-import type { AgFormatterInput } from '../../src/internal/types/AgMockConstructor.class';
 import type { AgFormattedLogMessage, AgLogMessage } from './AgLogger.types';
 import type { AgLogLevel } from './AgLogLevel.types';
+import type { AgFormatterInput } from './AgMockConstructor.class';
 
 // --- interfaces ---
 /**

--- a/packages/@agla-utils/ag-logger/shared/types/AgMockConstructor.class.ts
+++ b/packages/@agla-utils/ag-logger/shared/types/AgMockConstructor.class.ts
@@ -5,7 +5,7 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import type { AgFormatFunction, AgFormattedLogMessage, AgLogMessage } from '../../../shared/types';
+import type { AgFormatFunction, AgFormattedLogMessage, AgLogMessage } from '../../shared/types';
 
 /**
  * Format routine function type that processes AgLogMessage and returns formatted output.

--- a/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
+++ b/packages/@agla-utils/ag-logger/src/AgLogger.class.ts
@@ -18,6 +18,7 @@ import { AG_LOGGER_ERROR_MESSAGES, ERROR_TYPES } from '../shared/constants/agErr
 // internal
 import { AgLoggerConfig } from './internal/AgLoggerConfig.class';
 // plugins
+import type { AgMockFormatter } from './plugins/formatter/AgMockFormatter';
 import { ConsoleLogger, ConsoleLoggerMap } from './plugins/logger/ConsoleLogger';
 // utils
 import { AgLoggerGetMessage } from './utils/AgLoggerGetMessage';
@@ -165,6 +166,28 @@ export class AgLogger {
    */
   getFormatter(): AgFormatFunction {
     return this._config.formatter;
+  }
+
+  /**
+   * Gets the statistics formatter instance if available.
+   * Returns the AgMockFormatter instance that provides statistics tracking capabilities.
+   *
+   * @returns AgMockFormatter instance if available, null otherwise
+   * @since 0.2.0
+   */
+  getStatsFormatter(): AgMockFormatter | null {
+    return this._config.getStatsFormatter();
+  }
+
+  /**
+   * Checks if a statistics formatter instance is available for statistics access.
+   * Returns true if a mock formatter instance is currently stored.
+   *
+   * @returns True if statistics formatter instance is available, false otherwise
+   * @since 0.2.0
+   */
+  hasStatsFormatter(): boolean {
+    return this._config.hasStatsFormatter();
   }
 
   /**

--- a/packages/@agla-utils/ag-logger/src/__tests__/units/utils/AgLogValidators.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/__tests__/units/utils/AgLogValidators.spec.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from 'vitest';
 import { AG_LOGLEVEL } from '../../../../shared/types';
 import type { AgLogMessage } from '../../../../shared/types';
 import { AgLoggerError } from '../../../../shared/types/AgLoggerError.types';
-import type { AgFormatRoutine } from '../../../internal/types/AgMockConstructor.class';
+import type { AgFormatRoutine } from '../../../../shared/types/AgMockConstructor.class';
 import { AgMockFormatter } from '../../../plugins/formatter/AgMockFormatter';
 import { isAgMockConstructor, isValidLogLevel, validateLogLevel } from '../../../utils/AgLogValidators';
 

--- a/packages/@agla-utils/ag-logger/src/internal/AgLoggerConfig.class.ts
+++ b/packages/@agla-utils/ag-logger/src/internal/AgLoggerConfig.class.ts
@@ -22,6 +22,7 @@ import type { AgFormatFunction, AgLoggerFunction, AgLoggerOptions } from '../../
 // constants
 import { AG_LOGLEVEL } from '../../shared/types';
 // plugins
+import type { AgMockFormatter } from '../plugins/formatter/AgMockFormatter';
 import { NullFormatter } from '../plugins/formatter/NullFormatter';
 import { NullLogger } from '../plugins/logger/NullLogger';
 
@@ -75,9 +76,7 @@ export class AgLoggerConfig {
    * Contains the actual formatter instance when AgMockConstructor is used.
    * Provides access to getStats() and reset() methods for testing and monitoring.
    */
-  private _formatterInstance:
-    | { getStats(): { callCount: number; lastMessage: AgLogMessage | null }; reset(): void }
-    | null = null;
+  private _formatterInstance: AgMockFormatter | null = null;
 
   /**
    * Creates a new AgLoggerConfig instance with default settings.
@@ -344,7 +343,7 @@ export class AgLoggerConfig {
       if (isAgMockConstructor(input)) {
         // AgMockConstructor自体がデフォルトルーチンを提供
         const instance = new input();
-        this._formatterInstance = instance;
+        this._formatterInstance = instance as AgMockFormatter;
         resolvedOptions = { ...options, formatter: instance.execute };
       } else {
         // 通常のフォーマッタの場合はインスタンスをクリア
@@ -440,13 +439,24 @@ export class AgLoggerConfig {
   }
 
   /**
-   * Checks if a formatter instance is available for statistics access.
-   * Returns true if a mock formatter instance is currently stored.
+   * Gets the statistics formatter instance if available.
+   * Returns the AgMockFormatter instance that provides statistics tracking capabilities.
    *
-   * @returns True if formatter instance is available, false otherwise
+   * @returns AgMockFormatter instance if available, null otherwise
    * @since 0.2.0
    */
-  public hasFormatterInstance(): boolean {
+  public getStatsFormatter(): AgMockFormatter | null {
+    return this._formatterInstance;
+  }
+
+  /**
+   * Checks if a statistics formatter instance is available for statistics access.
+   * Returns true if a mock formatter instance is currently stored.
+   *
+   * @returns True if statistics formatter instance is available, false otherwise
+   * @since 0.2.0
+   */
+  public hasStatsFormatter(): boolean {
     return this._formatterInstance !== null;
   }
 }

--- a/packages/@agla-utils/ag-logger/src/internal/__tests__/AgLoggerConfig.formatterStats.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/internal/__tests__/AgLoggerConfig.formatterStats.spec.ts
@@ -8,7 +8,7 @@ import { AgLoggerConfig } from '../AgLoggerConfig.class';
 
 // types
 import type { AgLogMessage } from '../../../shared/types';
-import type { AgFormatRoutine, AgFormatterInput } from '../types/AgMockConstructor.class';
+import type { AgFormatRoutine, AgFormatterInput } from '../../../shared/types/AgMockConstructor.class';
 
 // plugins
 import { AgMockFormatter } from '../../plugins/formatter/AgMockFormatter';
@@ -55,7 +55,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
 
           // Assert: 設定成功とインスタンス保存
           expect(result).toBe(true);
-          expect(config.hasFormatterInstance()).toBe(true);
+          expect(config.hasStatsFormatter()).toBe(true);
           expect(config.getFormatterStats()).not.toBeNull();
         });
 
@@ -70,7 +70,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
 
           // Assert: 設定成功とインスタンス保存
           expect(result).toBe(true);
-          expect(config.hasFormatterInstance()).toBe(true);
+          expect(config.hasStatsFormatter()).toBe(true);
           expect(config.getFormatterStats()).not.toBeNull();
         });
 
@@ -85,7 +85,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
 
           // Assert: 設定成功とインスタンス保存
           expect(result).toBe(true);
-          expect(config.hasFormatterInstance()).toBe(true);
+          expect(config.hasStatsFormatter()).toBe(true);
           expect(config.getFormatterStats()).not.toBeNull();
         });
 
@@ -100,7 +100,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
 
           // Assert: 设定成功とインスタンス保存
           expect(result).toBe(true);
-          expect(config.hasFormatterInstance()).toBe(true);
+          expect(config.hasStatsFormatter()).toBe(true);
           expect(config.getFormatterStats()).not.toBeNull();
         });
       });
@@ -114,7 +114,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
           });
 
           // Pre-condition: インスタンスが保存されている
-          expect(config.hasFormatterInstance()).toBe(true);
+          expect(config.hasStatsFormatter()).toBe(true);
 
           // Act: 通常のフォーマッターに変更
           const result = config.setLoggerConfig({
@@ -123,7 +123,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
 
           // Assert: 設定成功とインスタンスクリア
           expect(result).toBe(true);
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
           expect(config.getFormatterStats()).toBeNull();
         });
       });
@@ -226,7 +226,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
 
           // Assert
           expect(stats).toBeNull();
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
         });
 
         it('Then should return null after setting standard formatter', () => {
@@ -239,7 +239,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
 
           // Assert
           expect(stats).toBeNull();
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
         });
       });
     });
@@ -313,7 +313,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
           expect(() => config.resetFormatterStats()).not.toThrow();
 
           // Assert: 状態は変わらない
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
           expect(config.getFormatterStats()).toBeNull();
         });
 
@@ -326,7 +326,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
           expect(() => config.resetFormatterStats()).not.toThrow();
 
           // Assert: 状態は変わらない
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
           expect(config.getFormatterStats()).toBeNull();
         });
       });
@@ -334,20 +334,20 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
   });
 
   /**
-   * Feature: hasFormatterInstance Method
+   * Feature: hasStatsFormatter Method
    * Given: 各種フォーマッター設定状態
-   * When: hasFormatterInstanceを呼び出した時
+   * When: hasStatsFormatterを呼び出した時
    * Then: 正しいブール値が返される
    */
-  describe('Feature: hasFormatterInstance Method', () => {
+  describe('Feature: hasStatsFormatter Method', () => {
     describe('Given various formatter configuration states', () => {
-      describe('When calling hasFormatterInstance', () => {
+      describe('When calling hasStatsFormatter', () => {
         it('Then should return false for uninitialized config', () => {
           // Arrange
           const config = new AgLoggerConfig();
 
           // Act & Assert
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
         });
 
         it('Then should return true for MockFormatter configurations', () => {
@@ -366,7 +366,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
               formatter: FormatterClass as AgFormatterInput,
             });
 
-            expect(config.hasFormatterInstance(), `Failed for formatter ${index}: ${FormatterClass.constructor.name}`)
+            expect(config.hasStatsFormatter(), `Failed for formatter ${index}: ${FormatterClass.constructor.name}`)
               .toBe(true);
           });
         });
@@ -377,7 +377,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
           config.setLoggerConfig({ formatter: JsonFormatter });
 
           // Act & Assert
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
         });
 
         it('Then should transition correctly between formatter types', () => {
@@ -387,23 +387,23 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
           // Act & Assert: MockFormatter -> Standard -> MockFormatter
 
           // 初期状態
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
 
           // MockFormatterに変更
           config.setLoggerConfig({
             formatter: MockFormatter.messageOnly as AgFormatterInput,
           });
-          expect(config.hasFormatterInstance()).toBe(true);
+          expect(config.hasStatsFormatter()).toBe(true);
 
           // 標準フォーマッターに変更
           config.setLoggerConfig({ formatter: JsonFormatter });
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
 
           // 再度MockFormatterに変更
           config.setLoggerConfig({
             formatter: MockFormatter.json as AgFormatterInput,
           });
-          expect(config.hasFormatterInstance()).toBe(true);
+          expect(config.hasStatsFormatter()).toBe(true);
         });
       });
     });
@@ -424,11 +424,11 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
           config.setLoggerConfig({ formatter: null as unknown as AgFormatterInput });
 
           // Act & Assert: エラーなく動作する
-          expect(() => config.hasFormatterInstance()).not.toThrow();
+          expect(() => config.hasStatsFormatter()).not.toThrow();
           expect(() => config.getFormatterStats()).not.toThrow();
           expect(() => config.resetFormatterStats()).not.toThrow();
 
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
           expect(config.getFormatterStats()).toBeNull();
         });
 
@@ -438,11 +438,11 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
           config.setLoggerConfig({ formatter: undefined as unknown as AgFormatterInput });
 
           // Act & Assert: エラーなく動作する
-          expect(() => config.hasFormatterInstance()).not.toThrow();
+          expect(() => config.hasStatsFormatter()).not.toThrow();
           expect(() => config.getFormatterStats()).not.toThrow();
           expect(() => config.resetFormatterStats()).not.toThrow();
 
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
           expect(config.getFormatterStats()).toBeNull();
         });
 
@@ -456,7 +456,7 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
 
           // Assert: 設定失敗とinstance状態のクリア
           expect(result).toBe(false);
-          expect(config.hasFormatterInstance()).toBe(false);
+          expect(config.hasStatsFormatter()).toBe(false);
           expect(config.getFormatterStats()).toBeNull();
         });
 
@@ -482,13 +482,13 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
 
             // MockFormatterかどうかで期待値を変える
             const isMockFormatter = formatter !== JsonFormatter;
-            expect(config.hasFormatterInstance(), `Instance check failed for configuration ${index}`).toBe(
+            expect(config.hasStatsFormatter(), `Instance check failed for configuration ${index}`).toBe(
               isMockFormatter,
             );
           });
 
           // Assert: 最終状態はMockFormatter
-          expect(config.hasFormatterInstance()).toBe(true);
+          expect(config.hasStatsFormatter()).toBe(true);
           expect(config.getFormatterStats()).not.toBeNull();
         });
 
@@ -506,9 +506,9 @@ describe('Feature: AgLoggerConfig FormatterStats機能', () => {
           });
 
           // Assert: 各configが独立している
-          expect(configs[0].hasFormatterInstance()).toBe(true);
-          expect(configs[1].hasFormatterInstance()).toBe(false);
-          expect(configs[2].hasFormatterInstance()).toBe(true);
+          expect(configs[0].hasStatsFormatter()).toBe(true);
+          expect(configs[1].hasStatsFormatter()).toBe(false);
+          expect(configs[2].hasStatsFormatter()).toBe(true);
 
           // 統計操作の独立性
           configs[0].formatter(createTestMessage('Config 0'));

--- a/packages/@agla-utils/ag-logger/src/internal/__tests__/AgLoggerConfig.mockConstructor.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/internal/__tests__/AgLoggerConfig.mockConstructor.spec.ts
@@ -46,7 +46,7 @@ describe('AgLoggerConfig: AgMockConstructor対応', () => {
     config.setLoggerConfig({ formatter: AgMockFormatter as unknown as AgFormatFunction });
 
     // formatterInstanceが設定されることを確認
-    expect(config.hasFormatterInstance()).toBe(true);
+    expect(config.hasStatsFormatter()).toBe(true);
   });
 
   it('自動生成されたインスタンスのexecuteがformatterに設定され、呼び出せる', () => {

--- a/packages/@agla-utils/ag-logger/src/internal/types/__tests__/AgMockConstructor.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/internal/types/__tests__/AgMockConstructor.spec.ts
@@ -9,7 +9,11 @@ import { describe, expect, it } from 'vitest';
 
 // Import types for testing
 import type { AgFormattedLogMessage, AgLogLevel, AgLogMessage } from '../../../../shared/types';
-import type { AgFormatRoutine, AgFormatterInput, AgMockConstructor } from '../AgMockConstructor.class';
+import type {
+  AgFormatRoutine,
+  AgFormatterInput,
+  AgMockConstructor,
+} from '../../../../shared/types/AgMockConstructor.class';
 
 /**
  * BDD Tests for AgMockConstructor type system

--- a/packages/@agla-utils/ag-logger/src/plugins/formatter/AgMockFormatter.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/formatter/AgMockFormatter.ts
@@ -7,7 +7,7 @@
 
 // types
 import type { AgFormatFunction, AgFormattedLogMessage, AgLogMessage } from '../../../shared/types';
-import type { AgFormatRoutine } from '../../internal/types/AgMockConstructor.class';
+import type { AgFormatRoutine } from '../../../shared/types/AgMockConstructor.class';
 
 /**
  * AgMockFormatter - Base class implementing AgMockConstructor interface

--- a/packages/@agla-utils/ag-logger/src/plugins/formatter/MockFormatter.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/formatter/MockFormatter.ts
@@ -5,19 +5,12 @@
 // https://opensource.org/licenses/MIT
 
 // types
-import type { AgFormatRoutine, AgMockConstructor } from '../../internal/types/AgMockConstructor.class';
+import type { AgFormatRoutine, AgMockConstructor } from '../../../shared/types/AgMockConstructor.class';
 
 // plugins
 import { AgMockFormatter } from './AgMockFormatter';
 // utilities
 import { AgToLabel } from '../../utils/AgLogHelpers';
-
-/**
- * MockFormatter.ts
- *
- * カリー化されたファクトリ関数を提供し、カスタムルーチンをbindした
- * MockFormatterクラスを生成する機能を実装
- */
 
 /**
  * ErrorThrowFormatter - 実行時にエラーメッセージを変更可能なフォーマッタ
@@ -136,6 +129,15 @@ export const MockFormatter = {
   prefixed: (prefix: string) => createMockFormatter((msg) => `${prefix}: ${msg.message}`),
 
   /**
+   * 固定値を返すフォーマッタファクトリ関数
+   * 指定した値を常に返すMockFormatterを作成
+   *
+   * @param value - 常に返す固定値
+   * @returns 固定値を返すMockFormatterクラス
+   */
+  returnValue: (value: string) => createMockFormatter(() => value),
+
+  /**
    * 動的エラーメッセージ対応フォーマッタ
    * 実行時にsetErrorMessageでエラーメッセージを変更可能
    *
@@ -144,3 +146,5 @@ export const MockFormatter = {
    */
   errorThrow: ErrorThrowFormatter,
 } as const;
+
+export default MockFormatter;

--- a/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/AgMockFormatter.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/AgMockFormatter.spec.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 // Import types and modules
 import type { AgLogLevel, AgLogMessage } from '../../../../shared/types';
-import type { AgFormatRoutine } from '../../../internal/types/AgMockConstructor.class';
+import type { AgFormatRoutine } from '../../../../shared/types/AgMockConstructor.class';
 import { AgMockFormatter } from '../AgMockFormatter';
 
 /**

--- a/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/MockFormatter.errorThrow.comprehensive.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/MockFormatter.errorThrow.comprehensive.spec.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest';
 // types
 import { AG_LOGLEVEL } from '../../../../shared/types';
 import type { AgLogMessage } from '../../../../shared/types';
-import type { AgFormatRoutine } from '../../../internal/types/AgMockConstructor.class';
+import type { AgFormatRoutine } from '../../../../shared/types/AgMockConstructor.class';
 
 // target
 import { MockFormatter } from '../MockFormatter';

--- a/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/MockFormatter.spec.ts
+++ b/packages/@agla-utils/ag-logger/src/plugins/formatter/__tests__/MockFormatter.spec.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest';
 // types
 import { AG_LOGLEVEL } from '../../../../shared/types';
 import type { AgFormatFunction, AgLogMessage } from '../../../../shared/types';
-import type { AgFormatRoutine } from '../../../internal/types/AgMockConstructor.class';
+import type { AgFormatRoutine } from '../../../../shared/types/AgMockConstructor.class';
 
 // target
 import { createMockFormatter, MockFormatter } from '../MockFormatter';

--- a/packages/@agla-utils/ag-logger/src/utils/AgLogValidators.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/AgLogValidators.ts
@@ -15,7 +15,7 @@ import { AgLoggerError } from 'shared/types/AgLoggerError.types';
 import { AG_LOGGER_ERROR_MESSAGES, ERROR_TYPES } from '../../shared/constants/agErrorMessages';
 import { AG_LOGLEVEL } from '../../shared/types';
 import type { AgLogLevel } from '../../shared/types';
-import type { AgMockConstructor } from '../internal/types/AgMockConstructor.class';
+import type { AgMockConstructor } from '../../shared/types/AgMockConstructor.class';
 import { valueToString } from './AgLogHelpers';
 
 export const isValidLogLevel = (logLevel: unknown): logLevel is AgLogLevel => {

--- a/packages/@agla-utils/ag-logger/src/utils/AgLoggerMethod.ts
+++ b/packages/@agla-utils/ag-logger/src/utils/AgLoggerMethod.ts
@@ -1,0 +1,65 @@
+// src/utils/AgLoggerMethod.ts
+// @(#) : Utility function to bind logger methods to class instances based on AG_LOGLEVEL_VALUES
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+import { AG_LOGLEVEL_KEYS } from '../../shared/types';
+import type { AgFormattedLogMessage } from '../../shared/types';
+
+/**
+ * Logger method type definition
+ */
+type LoggerMethod = (message: AgFormattedLogMessage) => void;
+
+/**
+ * Interface defining all required logger methods (excluding OFF level)
+ * (rule: consistent-type-definitions に合わせて type で定義)
+ */
+export type AgLoggerMethodsInterface = {
+  fatal(message: AgFormattedLogMessage): void;
+  error(message: AgFormattedLogMessage): void;
+  warn(message: AgFormattedLogMessage): void;
+  info(message: AgFormattedLogMessage): void;
+  debug(message: AgFormattedLogMessage): void;
+  trace(message: AgFormattedLogMessage): void;
+  verbose(message: AgFormattedLogMessage): void;
+  log(message: AgFormattedLogMessage): void;
+  default(message: AgFormattedLogMessage): void;
+  [key: string]: LoggerMethod | unknown;
+};
+
+// (unused) LoggerInstance 型は未使用のため削除
+
+/**
+ * Binds logger methods to a class instance based on AG_LOGLEVEL_KEYS.
+ * Only binds methods that exist on the target instance.
+ *
+ * @param instance - The class instance to bind logger methods to
+ * @returns The instance with bound logger methods
+ *
+ * @example
+ * ```typescript
+ * class MyClass {
+ *   info(message: AgFormattedLogMessage) { console.log(message); }
+ *   debug(message: AgFormattedLogMessage) { console.log(message); }
+ *   // warn method doesn't exist
+ * }
+ *
+ * const instance = new MyClass();
+ * const boundInstance = bindLoggerMethods(instance);
+ * // Only 'info' and 'debug' methods will be bound
+ * ```
+ */
+export const bindLoggerMethods = <T extends Partial<AgLoggerMethodsInterface>>(instance: T): T => {
+  AG_LOGLEVEL_KEYS
+    .map((levelKey) => levelKey.toLowerCase()) // map: create method names
+    .filter((methodName) => typeof instance[methodName] === 'function') // filter: only existing methods
+    .forEach((methodName) => { // forEach: bind methods (side effect allowed)
+      (instance as Record<string, unknown>)[methodName] = (instance[methodName] as LoggerMethod).bind(instance);
+    });
+
+  return instance;
+};

--- a/packages/@agla-utils/ag-logger/tests/integration/console-output/combinations/console-plugin-combinations.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/console-output/combinations/console-plugin-combinations.integration.spec.ts
@@ -1,0 +1,85 @@
+// tests/integration/console-output/combinations/console-plugin-combinations.integration.spec.ts
+// @(#) : Console Plugin Combinations Integration Tests - Console logger and formatter combinations
+//
+// Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+// テストフレームワーク: テスト実行・アサーション・モック
+import { describe, expect, it, vi } from 'vitest';
+
+// 共有定数: ログレベル定義
+import { AG_LOGLEVEL } from '@/shared/types';
+
+// テスト対象: AgLoggerとエントリーポイント
+import { AgLogger } from '@/AgLogger.class';
+
+// プラグイン（フォーマッター）: 出力フォーマット実装
+import { JsonFormatter } from '@/plugins/formatter/JsonFormatter';
+
+// プラグイン（ロガー）: 出力先実装とマップ
+import { ConsoleLogger, ConsoleLoggerMap } from '@/plugins/logger/ConsoleLogger';
+
+/**
+ * Console Plugin Combinations Integration Tests
+ *
+ * @description Console出力でのフォーマッターとロガーの組み合わせ統合動作を保証するテスト
+ * atsushifx式BDD：Given-When-Then形式で自然言語記述による仕様定義
+ */
+describe('Console Plugin Combinations Integration', () => {
+  const setupTestContext = (): void => {
+    vi.clearAllMocks();
+    AgLogger.resetSingleton();
+  };
+
+  /**
+   * Given: 実際のシステム統合環境でプラグイン組み合わせが使用される場合
+   * When: ConsoleLoggerMapとフォーマッターの実際の組み合わせを使用した時
+   * Then: 実環境での統合動作が適切に実行される
+   */
+  describe('Given real system integration uses plugin combinations', () => {
+    describe('When using actual ConsoleLoggerMap with formatter combinations', () => {
+      // 目的: ConsoleLoggerMap×各フォーマッターの実システム統合
+      it('Then should integrate correctly in real system scenarios', () => {
+        setupTestContext();
+
+        // Given: 実システム相当の組み合わせ設定
+        const consoleSpies = {
+          error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+          warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+          info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+          debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+        };
+
+        const logger = AgLogger.createLogger({
+          defaultLogger: ConsoleLogger,
+          formatter: JsonFormatter,
+          loggerMap: ConsoleLoggerMap,
+        });
+        logger.logLevel = AG_LOGLEVEL.DEBUG;
+
+        // When: 実システム相当の組み合わせ使用
+        logger.error('System error occurred', { code: 500, stack: 'error stack' });
+        logger.warn('System warning', { resource: 'memory', usage: '90%' });
+        logger.info('System info', { status: 'running', uptime: 12345 });
+        logger.debug('System debug', { query: 'SELECT * FROM table', time: 45 });
+
+        // Then: 実システム統合での適切な出力先振り分け
+        expect(consoleSpies.error).toHaveBeenCalledTimes(1);
+        expect(consoleSpies.warn).toHaveBeenCalledTimes(1);
+        expect(consoleSpies.info).toHaveBeenCalledTimes(1);
+        expect(consoleSpies.debug).toHaveBeenCalledTimes(1);
+
+        // Then: 実システム統合での適切なフォーマット
+        consoleSpies.error.mock.calls.forEach(([output]) => {
+          expect(() => JSON.parse(output)).not.toThrow();
+          const parsed = JSON.parse(output);
+          expect(parsed.level).toBe('ERROR');
+        });
+
+        Object.values(consoleSpies).forEach((spy) => spy.mockRestore());
+      });
+    });
+  });
+});

--- a/packages/@agla-utils/ag-logger/tests/integration/console-output/combinations/console-plugin-combinations.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/console-output/combinations/console-plugin-combinations.integration.spec.ts
@@ -37,10 +37,17 @@ describe('Console Plugin Combinations Integration', () => {
    * Given: 実際のシステム統合環境でプラグイン組み合わせが使用される場合
    * When: ConsoleLoggerMapとフォーマッターの実際の組み合わせを使用した時
    * Then: 実環境での統合動作が適切に実行される
+   *
+   * @description 実際のシステム統合環境におけるプラグイン組み合わせの動作テスト
+   * ConsoleLoggerMapとフォーマッターの組み合わせが実環境で適切に統合されることを検証
    */
   describe('Given real system integration uses plugin combinations', () => {
+    /**
+     * @description ConsoleLoggerMapとフォーマッター組み合わせの実システム統合テスト
+     * 実際の使用シナリオでの組み合わせ動作を検証
+     */
     describe('When using actual ConsoleLoggerMap with formatter combinations', () => {
-      // 目的: ConsoleLoggerMap×各フォーマッターの実システム統合
+      // ConsoleLoggerMap×各フォーマッターの実システム統合を検証
       it('Then should integrate correctly in real system scenarios', () => {
         setupTestContext();
 

--- a/packages/@agla-utils/ag-logger/tests/integration/console-output/loggers/console-logger-behavior.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/console-output/loggers/console-logger-behavior.integration.spec.ts
@@ -1,5 +1,5 @@
-// tests/integration/plugins/loggers/loggerTypes.integration.spec.ts
-// @(#) : Plugin Loggers Integration Tests - Different logger type behavior
+// tests/integration/console-output/loggers/console-logger-behavior.integration.spec.ts
+// @(#) : Console Logger Behavior Integration Tests - Console output behavior verification
 //
 // Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
@@ -10,7 +10,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // 共有定数: ログレベル定義
-import { AG_LOGLEVEL } from '../../../../shared/types';
+import { AG_LOGLEVEL } from '@/shared/types';
 
 // テスト対象: AgLoggerとエントリーポイント
 import { AgLogger } from '@/AgLogger.class';
@@ -24,12 +24,12 @@ import { ConsoleLogger, ConsoleLoggerMap } from '@/plugins/logger/ConsoleLogger'
 import { NullLogger } from '@/plugins/logger/NullLogger';
 
 /**
- * Plugin Loggers Integration Tests
+ * Console Logger Behavior Integration Tests
  *
- * @description 各種ロガープラグインの統合動作を保証するテスト
+ * @description Console出力での各種ロガーの振る舞いを保証するテスト
  * atsushifx式BDD：Given-When-Then形式で自然言語記述による仕様定義
  */
-describe('Plugin Loggers Integration', () => {
+describe('Console Logger Behavior Integration', () => {
   const setupTestContext = (): void => {
     vi.clearAllMocks();
     AgLogger.resetSingleton();

--- a/packages/@agla-utils/ag-logger/tests/integration/console-output/loggers/console-logger-behavior.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/console-output/loggers/console-logger-behavior.integration.spec.ts
@@ -37,10 +37,17 @@ describe('Console Logger Behavior Integration', () => {
    * Given: ConsoleLogger が使用される環境が存在する場合
    * When: コンソール出力が要求された時
    * Then: 適切なconsole.methodで出力される
+   *
+   * @description ConsoleLoggerの基本統合動作とconsole呼び出し確認テスト
+   * 実際のconsole.methodが適切に呼び出されることを検証
    */
   describe('Given ConsoleLogger is used in the environment', () => {
+    /**
+     * @description コンソール出力要求時の適切なconsole.method呼び出しテスト
+     * ConsoleLoggerが指定されたレベルのconsole.methodを正しく使用することを検証
+     */
     describe('When console output is requested', () => {
-      // 目的: ConsoleLoggerの基本統合動作とconsole呼び出し確認
+      // ConsoleLoggerの基本統合動作とconsole.methodの呼び出しを確認
       it('Then should output to appropriate console method', () => {
         setupTestContext();
 
@@ -74,10 +81,17 @@ describe('Console Logger Behavior Integration', () => {
    * Given: ConsoleLoggerMap が使用される環境が存在する場合
    * When: レベル固有のコンソール出力が要求された時
    * Then: 各レベルに応じた適切なconsole.methodで出力される
+   *
+   * @description ConsoleLoggerMapのレベル固有動作統合テスト
+   * 各ログレベルに応じて適切なconsole.methodに振り分けられることを検証
    */
   describe('Given ConsoleLoggerMap is used in the environment', () => {
+    /**
+     * @description レベル固有コンソール出力要求時の適切なmethod振り分けテスト
+     * ConsoleLoggerMapが各ログレベルに対して正しいconsole.methodを使用することを検証
+     */
     describe('When level-specific console output is requested', () => {
-      // 目的: ConsoleLoggerMap×JsonFormatterで適切なconsoleメソッドに振分け
+      // ConsoleLoggerMap×JsonFormatterで適切なconsoleメソッドに振り分けを確認
       it('Then should use correct console methods with JsonFormatter', () => {
         setupTestContext();
 
@@ -132,10 +146,17 @@ describe('Console Logger Behavior Integration', () => {
    * Given: NullLogger が使用される環境が存在する場合
    * When: ログ出力抑制が要求された時
    * Then: 何も出力されず、エラーも発生しない
+   *
+   * @description NullLoggerによるログ出力抑制動作統合テスト
+   * ログ出力を抑制し、エラーなく安全に動作することを検証
    */
   describe('Given NullLogger is used in the environment', () => {
+    /**
+     * @description ログ出力抑制要求時の安全な無出力動作テスト
+     * NullLoggerが出力を行わず、エラーも発生しないことを検証
+     */
     describe('When log output suppression is requested', () => {
-      // 目的: NullLogger使用時の安全な無出力動作
+      // NullLogger使用時の安全な無出力動作を確認
       it('Then should handle NullLogger with any formatter safely', () => {
         setupTestContext();
 
@@ -154,8 +175,12 @@ describe('Console Logger Behavior Integration', () => {
       });
     });
 
+    /**
+     * @description ロガーマップ内でのNullLoggerフォールバック使用テスト
+     * LoggerMap内でのNullLogger使用時の安定性を検証
+     */
     describe('When used as fallback in logger map', () => {
-      // 目的: ロガーマップ内でのNullLogger使用時の安定性
+      // ロガーマップ内でのNullLogger使用時の安定性を確認
       it('Then should work correctly as fallback logger in map configuration', () => {
         setupTestContext();
 
@@ -188,10 +213,17 @@ describe('Console Logger Behavior Integration', () => {
    * Given: モックロガーが使用される環境が存在する場合
    * When: テスト用のモック動作が要求された時
    * Then: 期待される動作でモック処理が実行される
+   *
+   * @description モックロガーの統合動作テスト
+   * テスト環境でのモックロガーの適切な動作を検証
    */
   describe('Given mock loggers are used in the environment', () => {
+    /**
+     * @description テスト用モック動作要求時の適切な処理テスト
+     * モックロガーが期待される動作で正しく処理されることを検証
+     */
     describe('When test mock behavior is requested', () => {
-      // 目的: モックロガーの基本統合動作
+      // モックロガーの基本統合動作を確認
       it('Then should work correctly with mock loggers', () => {
         setupTestContext();
 
@@ -220,8 +252,12 @@ describe('Console Logger Behavior Integration', () => {
       });
     });
 
+    /**
+     * @description モックロガーエラーシナリオ発生時の処理テスト
+     * モックロガーでエラーが発生した場合の適切な伝播を検証
+     */
     describe('When mock logger error scenarios occur', () => {
-      // 目的: モックロガーエラー時の処理
+      // モックロガーエラー時の適切な処理を確認
       it('Then should propagate mock logger errors correctly', () => {
         setupTestContext();
 

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/core/configuration-behavior.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/core/configuration-behavior.integration.spec.ts
@@ -50,10 +50,17 @@ describe('Core Configuration Behavior Integration', () => {
    * Given: 複雑な設定組み合わせが存在する場合
    * When: 部分的なロガーマップ設定を適用した時
    * Then: 適切なフォールバック動作が発生する
+   *
+   * @description 複雑な設定組み合わせでの動作統合テスト
+   * 部分的なロガーマップ設定と適切なフォールバック動作を検証
    */
   describe('Given complex configuration combinations exist', () => {
+    /**
+     * @description 部分的ロガーマップ設定適用時のフォールバック動作テスト
+     * 部分的なロガーマップ設定での適切なフォールバック処理を検証
+     */
     describe('When applying partial logger map configurations', () => {
-      // 目的: 部分ロガーマップと混在設定の適用検証
+      // 部分ロガーマップと混在設定の適用を検証
       it('Then should handle partial logger maps with proper fallback', (_ctx) => {
         const { mockLogger, mockFormatter } = setupTest();
 
@@ -95,8 +102,12 @@ describe('Core Configuration Behavior Integration', () => {
       });
     });
 
+    /**
+     * @description 段階的設定更新時の設定維持テスト
+     * 複数回の設定更新を通じて最終構成が正しく維持されることを検証
+     */
     describe('When updating configurations incrementally', () => {
-      // 目的: 段階的な設定更新を通じて最終構成が反映される
+      // 段階的な設定更新を通じて最終構成の反映を確認
       it('Then should maintain final configuration through multiple updates', (_ctx) => {
         const { mockFormatter } = setupTest();
 
@@ -132,10 +143,17 @@ describe('Core Configuration Behavior Integration', () => {
    * Given: 設定競合とエラーシナリオが存在する場合
    * When: フォーマッター競合が発生した時
    * Then: 適切なエラー処理が行われる
+   *
+   * @description 設定競合とエラーシナリオでの処理統合テスト
+   * フォーマッター競合や各種エラーシナリオでの適切な処理を検証
    */
   describe('Given configuration conflicts and error scenarios exist', () => {
+    /**
+     * @description フォーマッター競合発生時のエラー処理テスト
+     * フォーマッター競合が発生した場合の適切なエラー処理を検証
+     */
     describe('When formatter conflicts occur', () => {
-      // 目的: フォーマッター競合発生時のエラー処理
+      // フォーマッター競合発生時のエラー処理を確認
       it('Then should handle configuration conflicts gracefully', (_ctx) => {
         setupTest();
 
@@ -161,8 +179,12 @@ describe('Core Configuration Behavior Integration', () => {
       });
     });
 
+    /**
+     * @description ログ出力中の急速設定変更時の処理テスト
+     * ログ出力中に急速な設定変更が発生した場合の適切な処理を検証
+     */
     describe('When rapid configuration changes occur during logging', () => {
-      // 目的: ログ出力中の急速な設定変更に耐える
+      // ログ出力中の急速な設定変更に対する耐性を確認
       it('Then should handle rapid configuration changes during active logging', (_ctx) => {
         const { mockLogger: mockLogger1 } = setupTest();
 
@@ -199,8 +221,12 @@ describe('Core Configuration Behavior Integration', () => {
       });
     });
 
+    /**
+     * @description 複雑設定での混在エラーシナリオ処理テスト
+     * 複雑な設定下での混在エラーパターンの適切な処理を検証
+     */
     describe('When mixed error scenarios occur in complex configurations', () => {
-      // 目的: 複雑設定下での混在エラーパターン処理
+      // 複雑設定下での混在エラーパターン処理を確認
       it('Then should handle mixed error scenarios appropriately', (_ctx) => {
         const { mockLogger } = setupTest();
 

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/core/singleton-behavior.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/core/singleton-behavior.integration.spec.ts
@@ -6,20 +6,20 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// テストフレームワーク: テスト実行・アサーション・モック
+// Test framework: execution, assertion, mocking
 import { describe, expect, it, vi } from 'vitest';
 import type { TestContext } from 'vitest';
 
-// 共有型・定数: ログレベルと共通ユーティリティ
+// Shared types and constants: log levels and utilities
 import { AG_LOGLEVEL } from '@/shared/types';
 import type { AgLogMessage } from '@/shared/types';
 import { ENABLE } from '../../../../shared/constants';
 
-// テスト対象: AgLoggerとマネージャ
+// Test targets: main classes under test
 import { AgLogger } from '@/AgLogger.class';
 import { AgLoggerManager } from '@/AgLoggerManager.class';
 
-// プラグイン（フォーマッター/ロガー）: モックとJSON
+// Plugin implementations: formatters and loggers
 import MockFormatter from '@/plugins/formatter/MockFormatter';
 import { MockLogger } from '@/plugins/logger/MockLogger';
 import type { AgMockBufferLogger } from '@/plugins/logger/MockLogger';
@@ -141,21 +141,6 @@ describe('AgLogger Core Singleton Integration', () => {
         // Then: 新しいインスタンス取得時も同一性が保たれる
         const logger2 = AgLogger.createLogger();
         expect(logger1).toBe(logger2);
-      });
-    });
-
-    describe('When accessing rapidly and concurrently', () => {
-      // 目的: 急速なシングルトンアクセス時の一貫性
-      it('Then should handle rapid access patterns consistently', (_ctx) => {
-        setupTestContext(_ctx);
-
-        // When: 大量の並行アクセス
-        const loggers = Array.from({ length: 100 }, () => AgLogger.createLogger());
-
-        // Then: 全て同じインスタンスであることを確認
-        loggers.forEach((logger) => {
-          expect(logger).toBe(loggers[0]);
-        });
       });
     });
   });

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/manager/configuration-management.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/manager/configuration-management.integration.spec.ts
@@ -8,9 +8,10 @@
 
 // テストフレームワーク: テスト実行・アサーション・モック
 import { describe, expect, it, vi } from 'vitest';
+import type { TestContext } from 'vitest';
 
 // 共有型・定数: ログレベル定義と型
-import { AG_LOGLEVEL } from '../../../../shared/types';
+import { AG_LOGLEVEL } from '@/shared/types';
 
 // テスト対象: マネージャ本体
 import { AgLoggerManager } from '@/AgLoggerManager.class';
@@ -21,7 +22,32 @@ import { NullFormatter } from '@/plugins/formatter/NullFormatter';
 import { PlainFormatter } from '@/plugins/formatter/PlainFormatter';
 
 // プラグイン（ロガー）: 出力先実装とダミー
-import { ConsoleLogger } from '@/plugins/logger/ConsoleLogger';
+import { MockFormatter } from '@/plugins/formatter/MockFormatter';
+import { MockLogger } from '@/plugins/logger/MockLogger';
+import type { AgMockBufferLogger } from '@/plugins/logger/MockLogger';
+
+/**
+ * テスト初期設定
+ */
+const setupTestContext = (
+  _ctx?: TestContext,
+): { mockLogger: AgMockBufferLogger; mockFormatter: typeof MockFormatter.passthrough } => {
+  const _mockLogger = new MockLogger.buffer();
+  const _mockFormatter = MockFormatter.passthrough;
+
+  _ctx?.onTestFinished(() => {
+    AgLoggerManager.resetSingleton();
+    vi.clearAllMocks();
+  });
+
+  vi.clearAllMocks();
+  AgLoggerManager.resetSingleton();
+
+  return {
+    mockLogger: _mockLogger,
+    mockFormatter: _mockFormatter,
+  };
+};
 
 /**
  * AgLoggerManager Management Configuration Integration Tests
@@ -30,12 +56,6 @@ import { ConsoleLogger } from '@/plugins/logger/ConsoleLogger';
  * atsushifx式BDD：Given-When-Then形式で自然言語記述による仕様定義
  */
 describe('AgLoggerManager Management Configuration Integration', () => {
-  const setupTestContext = (): void => {
-    vi.clearAllMocks();
-    // Reset singleton instance for clean test state
-    AgLoggerManager.resetSingleton();
-  };
-
   /**
    * Given: 複合的な設定更新シナリオが存在する場合
    * When: 混在した設定更新を実行した時
@@ -45,15 +65,16 @@ describe('AgLoggerManager Management Configuration Integration', () => {
     describe('When executing mixed configuration updates', () => {
       // 目的: 複合的なsetManager更新での整合性維持
       it('Then should handle mixed configuration updates correctly', () => {
-        setupTestContext();
+        const { mockLogger, mockFormatter } = setupTestContext();
 
         // Given: 初期設定のマネージャー
-        AgLoggerManager.createManager({ defaultLogger: ConsoleLogger, formatter: JsonFormatter });
+        AgLoggerManager.createManager({ defaultLogger: mockLogger.default, formatter: mockFormatter });
         const manager = AgLoggerManager.getManager();
 
         // When: 段階的な複合設定更新
-        const firstLogger = vi.fn();
-        const firstFormatter = vi.fn().mockReturnValue('first');
+        const firstLoggerInstance = new MockLogger.buffer();
+        const firstLogger = firstLoggerInstance.info.bind(firstLoggerInstance);
+        const firstFormatter = MockFormatter.prefixed('first');
         manager.setLoggerConfig({
           defaultLogger: firstLogger,
           formatter: firstFormatter,
@@ -64,16 +85,18 @@ describe('AgLoggerManager Management Configuration Integration', () => {
         expect(typeof logger.getLoggerFunction(AG_LOGLEVEL.INFO)).toBe('function');
 
         // When: フォーマッターのみ更新
-        const secondFormatter = vi.fn().mockReturnValue('second');
+        const secondFormatter = MockFormatter.prefixed('second');
         manager.setLoggerConfig({ formatter: secondFormatter });
 
         // Then: フォーマッターのみ変更、ロガーは保持
-        const secondLogger = vi.fn();
+        const secondLoggerInstance = new MockLogger.buffer();
+        const secondLogger = secondLoggerInstance.info.bind(secondLoggerInstance);
         manager.setLoggerConfig({ defaultLogger: secondLogger });
         expect(typeof logger.getLoggerFunction(AG_LOGLEVEL.INFO)).toBe('function');
 
         // When: 専用ロガーマップ追加
-        const errorLogger = vi.fn();
+        const errorLoggerInstance = new MockLogger.buffer();
+        const errorLogger = errorLoggerInstance.error.bind(errorLoggerInstance);
         manager.setLoggerConfig({
           loggerMap: { [AG_LOGLEVEL.ERROR]: errorLogger },
         });
@@ -87,15 +110,16 @@ describe('AgLoggerManager Management Configuration Integration', () => {
     describe('When performing rapid configuration changes', () => {
       // 目的: 急速な設定変更連続時の最終状態の正当性
       it('Then should handle multiple rapid configuration changes correctly', () => {
-        setupTestContext();
+        const { mockLogger, mockFormatter } = setupTestContext();
 
         // Given: 高頻度変更対応の設定
-        AgLoggerManager.createManager({ defaultLogger: ConsoleLogger, formatter: JsonFormatter });
+        AgLoggerManager.createManager({ defaultLogger: mockLogger.default, formatter: mockFormatter });
         const manager = AgLoggerManager.getManager();
         const logger = manager.getLogger();
 
         // When: 急速な設定変更の実行
-        const loggers = Array.from({ length: 5 }, () => vi.fn());
+        const loggerInstances = Array.from({ length: 5 }, () => new MockLogger.buffer());
+        const loggers = loggerInstances.map((instance) => instance.info.bind(instance));
         const formatters = [JsonFormatter, PlainFormatter, NullFormatter, JsonFormatter, PlainFormatter];
 
         loggers.forEach((logger, index) => {
@@ -108,7 +132,7 @@ describe('AgLoggerManager Management Configuration Integration', () => {
         // Then: 最終設定（最後に適用されたもの）が有効
         const finalFn = logger.getLoggerFunction(AG_LOGLEVEL.INFO);
         expect(typeof finalFn).toBe('function');
-        expect(finalFn).not.toBe(ConsoleLogger); // 初期設定から変更済み
+        expect(finalFn).not.toBe(mockLogger.default); // 初期設定から変更済み
       });
     });
   });
@@ -122,20 +146,26 @@ describe('AgLoggerManager Management Configuration Integration', () => {
     describe('When switching between different formatters', () => {
       // 目的: フォーマッター変更が即時反映されることの確認
       it('Then should handle formatter changes with immediate effect', () => {
-        setupTestContext();
+        const { mockLogger } = setupTestContext();
 
         // Given: 初期フォーマッター設定
-        const firstFormatter = vi.fn().mockReturnValue('first format');
-        AgLoggerManager.createManager({ defaultLogger: ConsoleLogger, formatter: firstFormatter });
+        const firstFormatter = MockFormatter.returnValue('first formatter');
+        AgLoggerManager.createManager({
+          defaultLogger: mockLogger.default,
+          formatter: firstFormatter,
+        });
         const manager = AgLoggerManager.getManager();
 
         // When: フォーマッター変更
-        const secondFormatter = vi.fn().mockReturnValue('second format');
+        const secondFormatter = MockFormatter.returnValue('second formatter');
         manager.setLoggerConfig({ formatter: secondFormatter });
 
         // Then: 変更が即時反映される（実際のログ呼び出しで確認）
         const logger = manager.getLogger();
         logger.logLevel = AG_LOGLEVEL.INFO;
+
+        logger.info('test');
+        expect(mockLogger.getLastMessage(AG_LOGLEVEL.DEFAULT) as string).toBe('second formatter');
 
         // フォーマッター呼び出しを確認するため、実際にログ出力は行わない
         // 設定変更の確認のみ実施
@@ -145,11 +175,11 @@ describe('AgLoggerManager Management Configuration Integration', () => {
 
     describe('When working with different formatter types', () => {
       // 目的: 複数フォーマッター型の切替互換性検証
-      it('Then should work correctly with different formatter implementations', () => {
-        setupTestContext();
+      it('Then should work correctly with different formatter implementations', (_ctx) => {
+        const { mockLogger, mockFormatter } = setupTestContext(_ctx);
 
         // Given: 初期設定
-        AgLoggerManager.createManager({ defaultLogger: ConsoleLogger, formatter: JsonFormatter });
+        AgLoggerManager.createManager({ defaultLogger: mockLogger.default, formatter: mockFormatter });
         const manager = AgLoggerManager.getManager();
 
         // When: 異なるフォーマッター型への切り替え
@@ -174,23 +204,25 @@ describe('AgLoggerManager Management Configuration Integration', () => {
   describe('Given legacy API compatibility is required', () => {
     describe('When using legacy API methods', () => {
       // 目的: 旧API(bindLoggerFunction等)の互換動作確認
-      it('Then should handle legacy setLoggerConfig method correctly', () => {
-        setupTestContext();
+      it('Then should handle legacy setLoggerConfig method correctly', (_ctx) => {
+        const { mockLogger, mockFormatter } = setupTestContext(_ctx);
 
         // Given: レガシーAPI対応の設定
-        AgLoggerManager.createManager({ defaultLogger: ConsoleLogger, formatter: JsonFormatter });
+        AgLoggerManager.createManager({ defaultLogger: mockLogger.default, formatter: mockFormatter });
         const manager = AgLoggerManager.getManager();
         const logger = manager.getLogger();
 
         // When: レガシーAPIメソッドの使用
-        const customLogger = vi.fn();
+        const customLoggerInstance = new MockLogger.buffer();
+        const customLogger = customLoggerInstance.error.bind(customLoggerInstance);
         manager.bindLoggerFunction(AG_LOGLEVEL.ERROR, customLogger);
 
         // Then: レガシーAPIで設定したロガーが有効
         expect(logger.getLoggerFunction(AG_LOGLEVEL.ERROR)).toBe(customLogger);
 
         // When: 新APIとの組み合わせ
-        const defaultLogger = vi.fn();
+        const defaultLoggerInstance = new MockLogger.buffer();
+        const defaultLogger = defaultLoggerInstance.info.bind(defaultLoggerInstance);
         manager.setLoggerConfig({
           defaultLogger: defaultLogger,
         });
@@ -211,16 +243,22 @@ describe('AgLoggerManager Management Configuration Integration', () => {
     describe('When accessing state during complex updates', () => {
       // 目的: 複雑更新中の状態一貫性維持を検証
       it('Then should maintain state consistency during complex updates', () => {
-        setupTestContext();
+        const { mockLogger, mockFormatter } = setupTestContext();
 
         // Given: 複雑な初期設定
-        AgLoggerManager.createManager({ defaultLogger: ConsoleLogger, formatter: JsonFormatter });
+        AgLoggerManager.createManager({
+          defaultLogger: mockLogger.default,
+          formatter: mockFormatter,
+        });
         const manager = AgLoggerManager.getManager();
         const logger = manager.getLogger();
 
-        const defaultLogger = vi.fn();
-        const errorLogger = vi.fn();
-        const debugLogger = vi.fn();
+        const defaultLoggerInstance = new MockLogger.buffer();
+        const defaultLogger = defaultLoggerInstance.info.bind(defaultLoggerInstance);
+        const errorLoggerInstance = new MockLogger.buffer();
+        const errorLogger = errorLoggerInstance.error.bind(errorLoggerInstance);
+        const debugLoggerInstance = new MockLogger.buffer();
+        const debugLogger = debugLoggerInstance.debug.bind(debugLoggerInstance);
         const formatter = JsonFormatter;
 
         // When: 複雑な設定更新
@@ -239,7 +277,8 @@ describe('AgLoggerManager Management Configuration Integration', () => {
         expect(logger.getLoggerFunction(AG_LOGLEVEL.INFO)).toBe(defaultLogger);
 
         // When: デフォルトロガーのみ更新
-        const newDefaultLogger = vi.fn();
+        const newDefaultLoggerInstance = new MockLogger.buffer();
+        const newDefaultLogger = newDefaultLoggerInstance.info.bind(newDefaultLoggerInstance);
         manager.setLoggerConfig({ defaultLogger: newDefaultLogger });
 
         // Then: デフォルトロガー変更時の選択的適用

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/manager/singleton-management.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/manager/singleton-management.integration.spec.ts
@@ -6,19 +6,17 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// テストフレームワーク: テスト実行・アサーション・モック
+// Test framework: execution, assertion, mocking
 import { describe, expect, it, vi } from 'vitest';
 
-// 共有型・定数: ログレベル定義と型
+// Shared types and constants: log levels and type definitions
 import { AG_LOGLEVEL } from '@/shared/types';
 
-// テスト対象: マネージャ本体
+// Test targets: main classes under test
 import { AgLoggerManager } from '@/AgLoggerManager.class';
 
-// プラグイン（フォーマッター）: 出力フォーマット実装
+// Plugin implementations: formatters and loggers
 import { JsonFormatter } from '@/plugins/formatter/JsonFormatter';
-
-// プラグイン（ロガー）: 出力先実装とダミー
 import { MockFormatter } from '@/plugins/formatter/MockFormatter';
 import { MockLogger } from '@/plugins/logger/MockLogger';
 import type { AgMockBufferLogger } from '@/plugins/logger/MockLogger';

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/plugins/formatters/error-handling-behavior.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/plugins/formatters/error-handling-behavior.integration.spec.ts
@@ -7,9 +7,9 @@
 import { describe, expect, it } from 'vitest';
 
 // types
-import type { AgFormatRoutine } from '@/internal/types/AgMockConstructor.class';
 import { AG_LOGLEVEL } from '@/shared/types';
-import type { AgFormatFunction, AgLogMessage } from '@/shared/types';
+import type { AgLogMessage } from '@/shared/types';
+import type { AgFormatRoutine } from '../../../../../shared/types/AgMockConstructor.class';
 
 // target
 import { MockFormatter } from '@/plugins/formatter/MockFormatter';
@@ -38,11 +38,12 @@ describe('MockFormatter.errorThrow - 統合テスト', () => {
     it('AgLoggerConfigでErrorThrowFormatterを自動インスタンス化できる', () => {
       // Arrange
       const config = new AgLoggerConfig();
-      const FormatterClass = MockFormatter.errorThrow;
+      const FormatterClass = new MockFormatter.errorThrow();
+      FormatterClass.setErrorMessage('Default mock error');
 
       // Act - AgLoggerConfigにerrorThrowフォーマッタを設定
       const result = config.setLoggerConfig({
-        formatter: FormatterClass as unknown as AgFormatFunction,
+        formatter: FormatterClass.execute,
       });
 
       // Assert - 設定が成功
@@ -60,21 +61,23 @@ describe('MockFormatter.errorThrow - 統合テスト', () => {
     it('AgLoggerConfig経由でもsetErrorMessageが動作する', () => {
       // Arrange
       const config = new AgLoggerConfig();
-      const FormatterClass = MockFormatter.errorThrow;
+      const errorThrowFormatter = new MockFormatter.errorThrow();
 
       // インスタンスを直接作成してAgLoggerConfigに設定
-      const instance = new FormatterClass(dummyRoutine, 'Config integration test');
+      errorThrowFormatter.setErrorMessage('Config integration test');
       config.setLoggerConfig({
-        formatter: instance.execute,
+        formatter: errorThrowFormatter.execute,
       });
 
       const testMessage = createTestMessage();
 
       // Act & Assert - 初期メッセージでエラーを投げる
-      expect(() => config.formatter(testMessage)).toThrow('Config integration test');
+      expect(
+        () => config.formatter(testMessage),
+      ).toThrow('Config integration test');
 
       // Act - エラーメッセージを変更
-      instance.setErrorMessage('Runtime changed via config');
+      errorThrowFormatter.setErrorMessage('Runtime changed via config');
 
       // Assert - 変更されたメッセージでエラーを投げる
       expect(() => config.formatter(testMessage)).toThrow('Runtime changed via config');
@@ -95,7 +98,7 @@ describe('MockFormatter.errorThrow - 統合テスト', () => {
 
       // Act - カスタムクラスをAgLoggerConfigに設定
       const result = config.setLoggerConfig({
-        formatter: CustomErrorThrow as unknown as AgFormatFunction,
+        formatter: CustomErrorThrow,
       });
 
       // Assert - 設定が成功

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/plugins/formatters/formatter-types-behavior.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/plugins/formatters/formatter-types-behavior.integration.spec.ts
@@ -6,18 +6,18 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// テストフレームワーク: テスト実行・アサーション・モック
+// Test framework: execution, assertion, mocking
 import { describe, expect, it, vi } from 'vitest';
 import type { TestContext } from 'vitest';
 
-// 共有定数: ログレベル定義
+// Shared types and constants: log levels and type definitions
 import { AG_LOGLEVEL } from '@/shared/types';
 import type { AgLogMessage } from '@/shared/types';
 
-// テスト対象: AgLoggerとエントリーポイント
+// Test targets: main classes under test
 import { AgLogger } from '@/AgLogger.class';
 
-// プラグイン（フォーマッター）: 出力フォーマット実装
+// Plugin implementations: formatters and loggers
 import { MockFormatter } from '@/plugins/formatter/MockFormatter';
 import { NullFormatter } from '@/plugins/formatter/NullFormatter';
 import { PlainFormatter } from '@/plugins/formatter/PlainFormatter';
@@ -78,8 +78,6 @@ describe('Plugin Formatters Integration', () => {
         // Then: 正しいJSON構造で出力
         expect(mockLogger.getMessageCount()).toBe(1);
         const output = mockLogger.getMessages()[0] as string;
-
-        expect(() => JSON.parse(output)).not.toThrow();
         const parsed = JSON.parse(output);
         expect(parsed).toMatchObject({
           level: 'INFO',
@@ -121,8 +119,6 @@ describe('Plugin Formatters Integration', () => {
         // Then: 複雑データが適切にJSON化される
         expect(mockLogger.getMessageCount()).toBe(1);
         const output = mockLogger.getMessages()[0] as string;
-
-        expect(() => JSON.parse(output)).not.toThrow();
         const parsed = JSON.parse(output);
         expect(parsed.args[0]).toEqual(complexData);
       });
@@ -272,42 +268,6 @@ describe('Plugin Formatters Integration', () => {
 
         // Then: 出力が抑制される
         expect(mockLogger.getMessageCount()).toBe(0);
-      });
-    });
-
-    describe('When switching formatters with different data handling', () => {
-      // 目的: フォーマッター切り替え時の異なるデータ処理対応
-      it('Then should handle data differently based on current formatter', () => {
-        const { mockLogger } = setupTestContext();
-
-        // Given: 複雑データを含む環境
-        const logger = AgLogger.createLogger({
-          defaultLogger: mockLogger.getLoggerFunction(),
-          formatter: MockFormatter.json,
-        });
-        logger.logLevel = AG_LOGLEVEL.INFO;
-
-        const testData = { complex: true, nested: { value: 42 } };
-
-        // When: JsonFormatterで複雑データ出力
-        logger.info('json test', testData);
-        const jsonOutput = mockLogger.getMessages()[0] as string;
-
-        // Then: JSON構造として解析可能
-        expect(() => JSON.parse(jsonOutput)).not.toThrow();
-        const parsed = JSON.parse(jsonOutput);
-        expect(parsed.args[0]).toEqual(testData);
-
-        // When: PlainFormatterに切り替えて同じデータ出力
-        mockLogger.reset();
-        logger.setLoggerConfig({ formatter: PlainFormatter });
-        logger.info('plain test', testData);
-
-        const plainOutput = mockLogger.getMessages()[0] as string;
-
-        // Then: 平文形式で同じデータが処理される
-        expect(plainOutput).toContain('plain test');
-        expect(plainOutput).toContain('{"complex":true'); // オブジェクトは文字列化
       });
     });
   });

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/utils/creation-behavior.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/utils/creation-behavior.integration.spec.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // テストフレームワーク: テスト実行・アサーション・モック
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { TestContext } from 'vitest';
 
 // テスト対象: AgManagerUtils（ユーティリティ）と依存（AgLogger, Manager）
@@ -18,12 +18,28 @@ import { AgManager, createManager, getLogger } from '@/AgManagerUtils';
 /**
  * テストユーティリティ: 各テスト終了時にシングルトンとモックを初期化
  */
-const setupTestContext = (ctx: TestContext): void => {
-  ctx.onTestFinished(() => {
-    AgLogger.resetSingleton();
+import { MockFormatter } from '@/plugins/formatter/MockFormatter';
+import { MockLogger } from '@/plugins/logger/MockLogger';
+import type { AgMockConstructor } from '@/shared/types/AgMockConstructor.class';
+
+const setupTestContext = (_ctx?: TestContext): {
+  mockLogger: InstanceType<typeof MockLogger.buffer>;
+  mockFormatter: AgMockConstructor;
+} => {
+  const _mockLogger = new MockLogger.buffer();
+  const _mockFormatter = MockFormatter.passthrough;
+
+  // 初期設定
+  AgLoggerManager.resetSingleton();
+
+  _ctx?.onTestFinished(() => {
     AgLoggerManager.resetSingleton();
-    vi.clearAllMocks();
   });
+
+  return {
+    mockLogger: _mockLogger,
+    mockFormatter: _mockFormatter,
+  };
 };
 
 /**
@@ -41,8 +57,8 @@ describe('AgManagerUtils Core Creation Integration', () => {
   describe('Given manager is not yet created', () => {
     describe('When creating a manager via AgManagerUtils.createManager()', () => {
       // 目的: ユーティリティ経由の生成でAgManagerが設定されることを確認
-      it('Then should set AgManager and getLogger() should return AgLogger', (ctx) => {
-        setupTestContext(ctx);
+      it('Then should set AgManager and getLogger() should return AgLogger', (_ctx) => {
+        setupTestContext(_ctx);
 
         // Given: 初期状態の確認（未生成）
         expect(AgManager).toBeUndefined();

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/utils/creation-behavior.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/utils/creation-behavior.integration.spec.ts
@@ -6,18 +6,16 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-// テストフレームワーク: テスト実行・アサーション・モック
+// Test framework: execution, assertion, mocking
 import { describe, expect, it } from 'vitest';
 import type { TestContext } from 'vitest';
 
-// テスト対象: AgManagerUtils（ユーティリティ）と依存（AgLogger, Manager）
+// Test targets: main classes under test
 import { AgLogger } from '@/AgLogger.class';
 import { AgLoggerManager } from '@/AgLoggerManager.class';
 import { AgManager, createManager, getLogger } from '@/AgManagerUtils';
 
-/**
- * テストユーティリティ: 各テスト終了時にシングルトンとモックを初期化
- */
+// Plugin implementations: formatters and loggers
 import { MockFormatter } from '@/plugins/formatter/MockFormatter';
 import { MockLogger } from '@/plugins/logger/MockLogger';
 import type { AgMockConstructor } from '@/shared/types/AgMockConstructor.class';

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/utils/deletion-behavior.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/utils/deletion-behavior.integration.spec.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // テストフレームワーク: テスト実行・アサーション・モック
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { TestContext } from 'vitest';
 
 // 共有定数/型: エラーメッセージ
@@ -20,11 +20,29 @@ import { AgManager, createManager, getLogger, setupManager } from '@/AgManagerUt
 /**
  * テストユーティリティ: 各テスト終了時にシングルトンとモックを初期化
  */
-const setupTestContext = (ctx: TestContext): void => {
-  ctx.onTestFinished(() => {
+import { MockFormatter } from '@/plugins/formatter/MockFormatter';
+import { MockLogger } from '@/plugins/logger/MockLogger';
+import type { AgMockBufferLogger } from '@/plugins/logger/MockLogger';
+
+const setupTestContext = (_ctx?: TestContext): {
+  mockLogger: AgMockBufferLogger;
+  mockFormatter: typeof MockFormatter.passthrough;
+} => {
+  const _mockLogger = new MockLogger.buffer();
+  const _mockFormatter = MockFormatter.passthrough;
+
+  // 初期設定
+  AgLoggerManager.resetSingleton();
+
+  // 終了設定
+  _ctx?.onTestFinished(() => {
     AgLoggerManager.resetSingleton();
-    vi.clearAllMocks();
   });
+
+  return {
+    mockLogger: _mockLogger,
+    mockFormatter: _mockFormatter,
+  };
 };
 
 /**

--- a/packages/@agla-utils/ag-logger/tests/integration/mock-output/utils/initialization-error-handling.integration.spec.ts
+++ b/packages/@agla-utils/ag-logger/tests/integration/mock-output/utils/initialization-error-handling.integration.spec.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // テストフレームワーク
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { TestContext } from 'vitest';
 
 // 共有定数: エラーメッセージ
@@ -18,11 +18,30 @@ import { AgLoggerManager } from '@/AgLoggerManager.class';
 import { AgManager, createManager, getLogger, setupManager } from '@/AgManagerUtils';
 
 // テストユーティリティ: テスト終了時クリーンアップ
-const setupTestContext = (ctx: TestContext): void => {
-  ctx.onTestFinished(() => {
+import { MockFormatter } from '@/plugins/formatter/MockFormatter';
+import { MockLogger } from '@/plugins/logger/MockLogger';
+import type { AgMockBufferLogger } from '@/plugins/logger/MockLogger';
+import type { AgMockConstructor } from '@/shared/types/AgMockConstructor.class';
+
+const setupTestContext = (_ctx?: TestContext): {
+  mockLogger: AgMockBufferLogger;
+  mockFormatter: AgMockConstructor;
+} => {
+  const _mockLogger = new MockLogger.buffer();
+  const _mockFormatter = MockFormatter.passthrough;
+
+  // 初期設定
+  AgLoggerManager.resetSingleton();
+
+  // 終了設定
+  _ctx?.onTestFinished(() => {
     AgLoggerManager.resetSingleton();
-    vi.clearAllMocks();
   });
+
+  return {
+    mockLogger: _mockLogger,
+    mockFormatter: _mockFormatter,
+  };
 };
 
 /**


### PR DESCRIPTION
## Overview

This Pull Request refactors the **integration test suite** in the ag-logger package.  
The changes improve consistency in test mocks, reorganize test files by output type, and simplify setup and cleanup.  
The goal is to ensure tests are clearer, more maintainable, and aligned with recent refactorings of MockLogger and E2eMockLogger.

---

##  Changes

- [ ] Added/updated files or modules  
- [ ] Removed deprecated logic or configs  
- [x] Refactored for clarity/performance  
- [ ] Other (please describe below)  

**Details:**

- Reorganized integration tests by output type (`console-output`, `mock-output`)
- Unified test mocks with `E2eMockLogger` and `MockLogger` for consistent logging
- Replaced `vi.fn()` with `MockLogger` buffers in manager tests
- Updated error-handling and formatter-type tests to use mock plugins
- Refactored setup to use `MockLogger.buffer` and clarified mock types
- Simplified test context handling and removed unused `vi` mock cleanup
- Added cleanup hooks to reset `AgLogger` singleton and clear mocks
- Verified formatter stats tracking and logger recovery after errors

---

## Related Issues

> Related to #116 (AgLogger refactor tracking)  
> Related to #118 (Error handling improvements)

---

##  Checklist

- [x] Lint checks pass (`pnpm lint`)  
- [x] Tests pass (`pnpm test`)  
- [x] Documentation is updated (if applicable)  
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)  
- [x] Descriptions and examples are clear  

---

## Additional Notes

- Ensures integration tests reflect new refactorings in `MockLogger` and `E2eMockLogger`.  
- Provides a cleaner foundation for future test scenarios with consistent setup/teardown.  
