### PR TITLE
feat(@shared/types): clarify directory and add AglaError base class"

### DIFF
--- a/configs/ls-lint.yaml
+++ b/configs/ls-lint.yaml
@@ -9,8 +9,8 @@
 ls:
   .dir: kebab-case | regex:^[@#.]?[a-z-_]+$
   .ts: kebab-case
-  .types.ts: camelCase
-  .class.ts: PascalCase
+  .type.ts: camelCase | PascalCase
+  .class.ts: camelCase | PascalCase
 
   scripts:
     .*: kebab-case
@@ -23,8 +23,8 @@ ls:
 
   packages:
     .ts: camelCase | PascalCase
-    .type.ts: camelCase
-    .class.ts: PascalCase
+    .type.ts: camelCase | PascalCase
+    .class.ts: camelCase | PascalCase
 
 # ignore directories
 ignore:

--- a/shared/packages/types/configs/commitlint.config.ts
+++ b/shared/packages/types/configs/commitlint.config.ts
@@ -7,7 +7,7 @@
 // https://opensource.org/licenses/MIT
 
 // import commitlint config type
-import { default as baseConfig } from '../../configs/commitlint.config.base.js'; // ← .js拡張子を必ず付ける
+import { default as baseConfig } from '../../../../base/configs/commitlint.config.base.js'; // ← .js拡張子を必ず付ける
 
 import type { UserConfig } from '@commitlint/types';
 

--- a/shared/packages/types/configs/eslint.config.typed.js
+++ b/shared/packages/types/configs/eslint.config.typed.js
@@ -6,6 +6,15 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
+// resolve root directory
+import path from 'path';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+// directories
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const __rootDir = path.resolve(__dirname, '..');
+
 // parser
 import tsparser from '@typescript-eslint/parser';
 
@@ -26,7 +35,7 @@ export default [
       parser: tsparser,
       parserOptions: {
         project: ['./tsconfig.json'],
-        tsconfigRootDir: '.',
+        tsconfigRootDir: __rootDir,
         sourceType: 'module',
       },
     },

--- a/shared/packages/types/configs/tsup.config.module.ts
+++ b/shared/packages/types/configs/tsup.config.module.ts
@@ -18,7 +18,7 @@ export default defineConfig({
 
   // entry points
   entry: {
-    'index': './base/index.ts',
+    'index': './types/index.ts',
   },
 
   // sub-packages definition

--- a/shared/packages/types/configs/tsup.config.ts
+++ b/shared/packages/types/configs/tsup.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
 
   // entry points
   entry: {
-    'index': './base/index.ts',
+    'index': './types/index.ts',
   },
 
   // sub packages definition

--- a/shared/packages/types/configs/vitest.config.e2e.ts
+++ b/shared/packages/types/configs/vitest.config.e2e.ts
@@ -27,13 +27,19 @@ export default mergeConfig(baseConfig, {
       'tests/e2e/**/*.test.ts',
       'tests/e2e/**/*.spec.ts',
     ],
-    caches: {
-      dir: path.resolve(__dirname, '../../../.cache/vitest-cache/e2e/'),
+    exclude: [
+      '**/__tests__/*',
+    ],
+    cachesDir: path.resolve(__dirname, '../../../.cache/vitest-cache/e2e/'),
+    // parallel test
+    sequence: {
+      concurrent: true,
     },
   },
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, '../src'),
-    },
+    alias: [
+      { find: '@', replacement: path.resolve(__dirname, '../src') },
+      { find: /^@\/shared/, replacement: path.resolve(__dirname, '../shared') },
+    ],
   },
 });

--- a/shared/packages/types/configs/vitest.config.functional.ts
+++ b/shared/packages/types/configs/vitest.config.functional.ts
@@ -1,5 +1,5 @@
-// src: shared/common/configs/vitest.config.unit.ts
-// @(#) : vitest config for unit test
+// src: shared/common/configs/vitest.config.functional.ts
+// @(#) : vitest config for functional test
 //
 // Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
@@ -22,16 +22,16 @@ import baseConfig from '../../../../base/configs/vitest.config.base';
 export default mergeConfig(baseConfig, {
   test: {
     include: [
-      // Unit Test - pure unit tests for individual functions/methods
-      'src/**/__tests__/**/*.spec.ts',
-      'src/**/__tests__/**/*.test.ts',
+      // Functional Test - single feature complete behavior verification
+      'src/**/__tests__/functional/**/*.spec.ts',
+      'src/**/__tests__/functional/**/*.test.ts',
     ],
     exclude: [
-      'src/**/__tests__/functional/**/*',
+      'src/**/__tests__/units/**/*',
       'tests/**/*',
     ],
-    cacheDir: path.resolve(__dirname, '../../../.cache/vitest-cache/unit/'),
-    // sequential test execution to avoid singleton state conflicts
+    cacheDir: path.resolve(__dirname, '../../../.cache/vitest-cache/functional/'),
+    // sequential test execution to avoid singleton state conflicts in functional tests
     sequence: {
       concurrent: false,
     },

--- a/shared/packages/types/configs/vitest.config.integration.ts
+++ b/shared/packages/types/configs/vitest.config.integration.ts
@@ -1,5 +1,5 @@
-// src: shared/common/configs/vitest.config.integration.ts
-// @(#) : vitest config for integration test
+// src: shared/common/configs/vitest.config.ci.ts
+// @(#) : vitest config for CI test
 //
 // Copyright (c) 2025 atsushifx <https://github.com/atsushifx>
 //
@@ -26,12 +26,18 @@ export default mergeConfig(baseConfig, {
       'tests/integration/**/*.test.ts',
       'tests/integration/**/*.spec.ts',
     ],
-    caches: {
-      dir: path.resolve(__dirname, '../../../.cache/vitest-cache/integration/'),
+    exclude: [
+      '**/__tests__/*',
+    ],
+    cacheDir: path.resolve(__dirname, '../../../.cache/vitest-cache/ci/'),
+    // parallel test
+    sequence: {
+      concurrent: true,
     },
   },
   resolve: {
     alias: {
+      '@/shared': path.resolve(__dirname, '../shared'),
       '@': path.resolve(__dirname, '../src'),
     },
   },

--- a/shared/packages/types/package.json
+++ b/shared/packages/types/package.json
@@ -30,8 +30,9 @@
     "lint:all": "pnpm run lint && pnpm run lint:types",
     "lint:fix": "pnpm run lint --fix",
     "lint:secrets": "secretlint --secretlintrc ./configs/secretlint.config.yaml --secretlintignore .gitignore --maskSecrets **/*",
-    "test:all": "pnpm run test:develop && pnpm run test:ci && pnpm run test:e2e",
+    "test:all": "pnpm run test:develop && pnpm run test:functional && pnpm run test:ci && pnpm run test:e2e",
     "test:develop": "pnpm exec vitest run --config ./configs/vitest.config.unit.ts",
+    "test:functional": "pnpm exec vitest run --config ./configs/vitest.config.functional.ts",
     "test:ci": "pnpm exec vitest run --config ./configs/vitest.config.integration.ts",
     "test:e2e": "pnpm exec vitest run --config ./configs/vitest.config.e2e.ts",
     "sync:configs": "bash ../../../scripts/sync-configs.sh . "

--- a/shared/packages/types/tsconfig.json
+++ b/shared/packages/types/tsconfig.json
@@ -8,7 +8,7 @@
 {
   "extends": "../../../base/configs/tsconfig.base.json",
   "include": [
-    "base/**/*.ts"
+    "types/*.ts"
   ],
   "exclude": [
     ".git",
@@ -23,10 +23,9 @@
     // "outDir": "lib",
     "rootDir": "./",
     // aliases
-    "baseUrl": "./",
+    "baseUrl": "./"
     // "paths": {},
     // types
     // cache
-    "tsBuildInfoFile": ".cache/tsbuild-cache/tsbuildinfo"
   }
 }

--- a/shared/packages/types/types/AglaError.types.ts
+++ b/shared/packages/types/types/AglaError.types.ts
@@ -1,0 +1,48 @@
+// shared/types/error.types.ts
+// @(#) : Base Error Classes for ag-logger Package
+//
+// Copyright (c) 2025 atsushifx <http://github.com/atsushifx>
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+/**
+ * Abstract base error class for all ag-logger related errors.
+ * Provides structured error handling with error codes and context information.
+ */
+export abstract class AglaError extends Error {
+  /** The error type identifying the specific type of error. */
+  public readonly errorType: string;
+
+  /** Optional context information providing additional details about the error. */
+  public readonly context?: Record<string, unknown>;
+
+  /**
+   * Creates a new AglaError instance.
+   *
+   * @param errorType - The error type identifying the specific type of error
+   * @param message - The human-readable error message
+   * @param context - Optional context information for debugging
+   */
+  constructor(errorType: string, message: string, context?: Record<string, unknown>) {
+    super(message);
+    this.errorType = errorType;
+    this.context = context;
+    this.name = this.constructor.name;
+
+    // NOTE: Do not change - Error.captureStackTrace check is intentional for Node.js compatibility
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+
+  /**
+   * Returns a string representation of the error including error type, message, and context.
+   *
+   * @returns A formatted string containing the error type, message, and context (if present)
+   */
+  toString(): string {
+    const contextStr = this.context ? JSON.stringify(this.context) : '';
+    return `${this.errorType}: ${this.message}${contextStr ? ` ${contextStr}` : ''}`;
+  }
+}

--- a/shared/packages/types/types/index.ts
+++ b/shared/packages/types/types/index.ts
@@ -6,4 +6,4 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-export {}; // export nothing to treat file as module – prevents build errors
+export * from './AglaError.types';


### PR DESCRIPTION
## ✨ Overview

This Pull Request refactors the `@shared/types` package for clarity and extends its functionality.  
Specifically, it clarifies the directory structure and introduces a new abstract base error class `AglaError`  
to support structured error handling across the monorepo.

## 🔧 Changes

- Renamed `base/index.ts` to `types/index.ts` for clarity
- Added `AglaError.types.ts` with an abstract `AglaError` class
- Exported `AglaError` from `types/index.ts`

## 📂 Related Issues


## ✅ Checklist

Please confirm the following before requesting review:

- [x] Lint checks pass (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Descriptions and examples are clear

---

## 💬 Additional Notes

This change lays the foundation for consistent error handling across the ESTA ecosystem.  
Future work will integrate `AglaError` with `EstaError` and `ErrorResult` for unified error management.
